### PR TITLE
Makefile: Fix bashism when building on Ubuntu + dash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ container: .container-$(DOTFILE_IMAGE) container-name
 	    Dockerfile.in > .dockerfile-$(ARCH)
 	@docker build -t $(IMAGE):$(VERSION) -f .dockerfile-$(ARCH) .
 	@docker images -q $(IMAGE):$(VERSION) > $@
-	@if [ "$(ARCH)" == "amd64" ]; then \
+	@if [ "$(ARCH)" = "amd64" ]; then \
 	    docker tag $(IMAGE):$(VERSION) $(LEGACY_IMAGE):$(VERSION); \
 	fi
 
@@ -123,7 +123,7 @@ push: .push-$(DOTFILE_IMAGE) push-name
 .push-$(DOTFILE_IMAGE): .container-$(DOTFILE_IMAGE)
 	@gcloud docker push $(IMAGE):$(VERSION)
 	@docker images -q $(IMAGE):$(VERSION) > $@
-	@if [ "$(ARCH)" == "amd64" ]; then \
+	@if [ "$(ARCH)" = "amd64" ]; then \
 	    gcloud docker push $(LEGACY_IMAGE):$(VERSION); \
 	fi
 


### PR DESCRIPTION
 Reference: https://wiki.ubuntu.com/DashAsBinSh#A.5B

 Ubuntu's /bin/sh is /bin/dash and '==' triggers an error:
 >> /bin/sh: 1: [: amd64: unexpected operator

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/git-sync/23)
<!-- Reviewable:end -->
