### PR TITLE
Use bare name for DEST in example

### DIFF
--- a/demo/config/pod.yaml
+++ b/demo/config/pod.yaml
@@ -16,7 +16,7 @@ spec:
     - name: GIT_SYNC_REPO
       value: https://github.com/GoogleCloudPlatform/kubernetes.git
     - name: GIT_SYNC_DEST
-      value: /git
+      value: git
   - name: hugo
     image: gcr.io/google_containers/hugo
     imagePullPolicy: Always


### PR DESCRIPTION
Using a path for DEST will fail in subsequent syncs #8.
Using a bare name in examples.