### PR TITLE
update pod config

### DIFF
--- a/demo/config/pod.yaml
+++ b/demo/config/pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: git-sync
-    image: gcr.io/google_containers/git-sync
+    image: gcr.io/google_containers/git-sync:v2.0.4
     imagePullPolicy: Always
     volumeMounts:
     - name: markdown


### PR DESCRIPTION
- Fixes #42
- now uses v2.0.4 which is current latest

NOTE: Hugo is not versioned on GCR hence still using the latest image.