### PR TITLE
Update OWNERS to latest state

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,3 @@
-assignees:
-- mikedanese
-- paulbakker
-
+maintainers:
+- thockin
+- stp-ip


### PR DESCRIPTION
Use latest governance state from Kubernetes and document current maintainers.