### PR TITLE
Run Go build-image without TTY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ build: bin/$(ARCH)/$(BIN)
 bin/$(ARCH)/$(BIN): build-dirs
 	@echo "building: $@"
 	@docker run                                                            \
-	    -ti                                                                \
+	    -i                                                                 \
 	    -u $$(id -u):$$(id -g)                                             \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \


### PR DESCRIPTION
AFAIK it's not necessary to run the build-image with TTY and the `-t` flag can just be omitted as it breaks some CI builds trying to run `make container` when TTY isn't allowed.