### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ symlink.
 
 ```
 # build the container
-make container REGISTRY=registry TAG=tag
+make container REGISTRY=registry VERSION=tag
 
 # run the container
 docker run -d \


### PR DESCRIPTION
The README instructs the user to overwrite the TAG variable to set the
tag on `make container`. However, the user should actually overwrite the
`VERSION` variable.