### PR TITLE
Clean up failed clones

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -336,7 +336,20 @@ func cloneRepo(repo, branch, rev string, depth int, gitRoot string) error {
 	args = append(args, repo, gitRoot)
 	_, err := runCommand("", "git", args...)
 	if err != nil {
-		return err
+		if strings.Contains(err.Error(), "already exists and is not an empty directory") {
+			// Maybe a previous run crashed?  Git won't use this dir.
+			log.V(0).Infof("%s exists and is not empty (previous crash?), cleaning up", gitRoot)
+			err := os.RemoveAll(gitRoot)
+			if err != nil {
+				return err
+			}
+			_, err = runCommand("", "git", args...)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 	log.V(0).Infof("cloned %s", repo)
 

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -89,7 +89,8 @@ function GIT_SYNC() {
 
 function remove_sync_container() {
     # Verify the container is running using 'docker top' before removing
-    docker top $CONTAINER_NAME >/dev/null 2>&1 && docker rm -f $CONTAINER_NAME
+    docker top $CONTAINER_NAME >/dev/null 2>&1 && \
+    docker rm -f $CONTAINER_NAME >/dev/null 2>&1
 }
 
 REPO="$DIR/repo"
@@ -405,6 +406,39 @@ sleep 3
 assert_link_exists "$ROOT"/link
 assert_file_exists "$ROOT"/link/file
 assert_file_eq "$ROOT"/link/file "$TESTCASE"
+# Wrap up
+pass
+
+# Test syncing after a crash
+testcase "crash-cleanup-retry"
+# First sync
+echo "$TESTCASE 1" > "$REPO"/file
+git -C "$REPO" commit -qam "$TESTCASE 1"
+GIT_SYNC \
+    --logtostderr \
+    --v=5 \
+    --one-time \
+    --repo="$REPO" \
+    --root="$ROOT" \
+    --dest="link" > "$DIR"/log."$TESTCASE" 2>&1 &
+sleep 3
+assert_link_exists "$ROOT"/link
+assert_file_exists "$ROOT"/link/file
+assert_file_eq "$ROOT"/link/file "$TESTCASE 1"
+# Corrupt it
+rm -f "$ROOT"/link
+# Try again
+GIT_SYNC \
+    --logtostderr \
+    --v=5 \
+    --one-time \
+    --repo="$REPO" \
+    --root="$ROOT" \
+    --dest="link" > "$DIR"/log."$TESTCASE" 2>&1 &
+sleep 3
+assert_link_exists "$ROOT"/link
+assert_file_exists "$ROOT"/link/file
+assert_file_eq "$ROOT"/link/file "$TESTCASE 1"
 # Wrap up
 pass
 


### PR DESCRIPTION
If an initial clone crashes, it can leave the git-root in a bad state
such that git can't retry the clone.  This change forces it to clean up
the mess and retry.

Fixes #105 