### PR TITLE
Update example volume mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ make container REGISTRY=registry VERSION=tag
 
 # run the container
 docker run -d \
-    -v /tmp/git-data:/git \
+    -v /tmp/git-data:/tmp/git \
     registry/git-sync:tag \
         --repo=https://github.com/kubernetes/git-sync
         --branch=master


### PR DESCRIPTION
Since the default clone path is $HOME/git and the docker image sets $HOME to /tmp, we have to mount the volume at `/tmp/git` for the container to write files to the volume. As written, the example doesn't write to the volume.