### PR TITLE
Switch to rev-parse

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -357,7 +357,7 @@ func cloneRepo(repo, branch, rev string, depth int, gitRoot string) error {
 }
 
 func hashForRev(rev, gitRoot string) (string, error) {
-	output, err := runCommand(gitRoot, "git", "rev-list", "-n1", rev)
+	output, err := runCommand(gitRoot, "git", "rev-parse", rev)
 	if err != nil {
 		return "", err
 	}
@@ -365,8 +365,8 @@ func hashForRev(rev, gitRoot string) (string, error) {
 }
 
 func revIsHash(rev, gitRoot string) (bool, error) {
-	// If a rev is a tag name or HEAD, rev-list will produce the git hash.  If
-	// it is already a git hash, the output will be the same hash.  Of course, a
+	// If rev is a tag name or HEAD, rev-parse will produce the git hash.  If
+	// rev is already a git hash, the output will be the same hash.  Of course, a
 	// user could specify "abc" and match "abcdef12345678", so we just do a
 	// prefix match.
 	output, err := hashForRev(rev, gitRoot)
@@ -426,7 +426,7 @@ func getRevs(localDir, branch, rev string) (string, string, error) {
 	if rev == "HEAD" {
 		ref = "refs/heads/" + branch
 	} else {
-		ref = "refs/tags/" + rev + "^{}"
+		ref = "refs/tags/" + rev
 	}
 
 	// Figure out what hash the remote resolves ref to.

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -56,9 +56,9 @@ function finish() {
 
 trap finish INT EXIT
 
-#########################
+# #####################
 # main
-#########################
+# #####################
 
 # Build it
 make container REGISTRY=e2e TAG=$(make -s version)
@@ -244,6 +244,52 @@ pass
 
 # Test tag syncing
 testcase "tag-sync"
+TAG="$TESTCASE"--TAG
+# First sync
+echo "$TESTCASE 1" > "$REPO"/file
+git -C "$REPO" commit -qam "$TESTCASE 1"
+git -C "$REPO" tag -f "$TAG" >/dev/null
+GIT_SYNC \
+    --logtostderr \
+    --v=5 \
+    --wait=0.1 \
+    --repo="$REPO" \
+    --rev="$TAG" \
+    --root="$ROOT" \
+    --dest="link" > "$DIR"/log."$TESTCASE" 2>&1 &
+sleep 3
+assert_link_exists "$ROOT"/link
+assert_file_exists "$ROOT"/link/file
+assert_file_eq "$ROOT"/link/file "$TESTCASE 1"
+# Add something and move the tag forward
+echo "$TESTCASE 2" > "$REPO"/file
+git -C "$REPO" commit -qam "$TESTCASE 2"
+git -C "$REPO" tag -f "$TAG" >/dev/null
+sleep 3
+assert_link_exists "$ROOT"/link
+assert_file_exists "$ROOT"/link/file
+assert_file_eq "$ROOT"/link/file "$TESTCASE 2"
+# Move the tag backward
+git -C "$REPO" reset -q --hard HEAD^
+git -C "$REPO" tag -f "$TAG" >/dev/null
+sleep 3
+assert_link_exists "$ROOT"/link
+assert_file_exists "$ROOT"/link/file
+assert_file_eq "$ROOT"/link/file "$TESTCASE 1"
+# Add something after the tag
+echo "$TESTCASE 3" > "$REPO"/file
+git -C "$REPO" commit -qam "$TESTCASE 3"
+sleep 3
+assert_link_exists "$ROOT"/link
+assert_file_exists "$ROOT"/link/file
+assert_file_eq "$ROOT"/link/file "$TESTCASE 1"
+# Wrap up
+remove_sync_container
+wait
+pass
+
+# Test tag syncing with annotated tags
+testcase "tag-sync-annotated"
 TAG="$TESTCASE"--TAG
 # First sync
 echo "$TESTCASE 1" > "$REPO"/file


### PR DESCRIPTION
This handles non-annotated tags, which were not handled well before.  It
does mean that we use the hash of the (annotated) tag object instead of
the commit, but that seems OK.

Added a test case.

Fixes #116 