### PR TITLE
fix e2e script to work with os/arch tags

### DIFF
--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -83,7 +83,7 @@ function GIT_SYNC() {
         -u $(id -u):$(id -g) \
         -v "$DIR":"$DIR" \
         --rm \
-        e2e/git-sync:$(make -s version) \
+        e2e/git-sync:$(make -s version)__$(go env GOOS)_$(go env GOARCH) \
         "$@"
 }
 


### PR DESCRIPTION
Fix tests after recent changes to produce manifests modified the tag names.