### PR TITLE
Trim ".git" suffix in git repo URL

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -136,7 +136,7 @@ func main() {
 		os.Exit(1)
 	}
 	if *flDest == "" {
-		parts := strings.Split(strings.Trim(*flRepo, "/"), "/")
+		parts := strings.Split(strings.TrimSuffix(strings.Trim(*flRepo, "/"), ".git"), "/")
 		*flDest = parts[len(parts)-1]
 	}
 	if strings.Contains(*flDest, "/") {


### PR DESCRIPTION
Both GitHub and GitLab web provides URL with ".git" suffix,
and `git clone`'s default behavior is to get rid of it,
so it's better to trim it as the default destination.