### PR TITLE
Add flags/env-vars for additional SSH options

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -69,6 +69,8 @@ var flPassword = flag.String("password", envString("GIT_SYNC_PASSWORD", ""),
 
 var flSSH = flag.Bool("ssh", envBool("GIT_SYNC_SSH", false),
 	"use SSH for git operations")
+var flSSHSecret = flag.String("ssh-key", envString("GIT_SSH_KEY", "/etc/git-secret/ssh"),
+	"the ssh key to use")
 var flSSHKnownHosts = flag.Bool("ssh-known-hosts", envBool("GIT_KNOWN_HOSTS", true),
 	"enable SSH known_hosts verification")
 
@@ -513,7 +515,7 @@ func setupGitAuth(username, password, gitURL string) error {
 func setupGitSSH(setupKnownHosts bool) error {
 	log.V(1).Infof("setting up git SSH credentials")
 
-	var pathToSSHSecret = "/etc/git-secret/ssh"
+	var pathToSSHSecret = *flSSHSecret
 	var pathToSSHKnownHosts = "/etc/git-secret/known_hosts"
 
 	fileInfo, err := os.Stat(pathToSSHSecret)

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -73,6 +73,8 @@ var flSSHSecret = flag.String("ssh-key", envString("GIT_SSH_KEY", "/etc/git-secr
 	"the ssh key to use")
 var flSSHKnownHosts = flag.Bool("ssh-known-hosts", envBool("GIT_KNOWN_HOSTS", true),
 	"enable SSH known_hosts verification")
+var flSSHKnownHostsFile = flag.String("ssh-known-hosts-file", envString("GIT_KNOWN_HOSTS_FILE", "/etc/git-secret/known_hosts"),
+	"the known hosts file to use")
 
 var flCookieFile = flag.Bool("cookie-file", envBool("GIT_COOKIE_FILE", false),
 	"use git cookiefile")
@@ -516,7 +518,7 @@ func setupGitSSH(setupKnownHosts bool) error {
 	log.V(1).Infof("setting up git SSH credentials")
 
 	var pathToSSHSecret = *flSSHSecret
-	var pathToSSHKnownHosts = "/etc/git-secret/known_hosts"
+	var pathToSSHKnownHosts = *flSSHKnownHostsFile
 
 	fileInfo, err := os.Stat(pathToSSHSecret)
 	if err != nil {

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -69,11 +69,11 @@ var flPassword = flag.String("password", envString("GIT_SYNC_PASSWORD", ""),
 
 var flSSH = flag.Bool("ssh", envBool("GIT_SYNC_SSH", false),
 	"use SSH for git operations")
-var flSSHKeyFile = flag.String("ssh-key-file", envString("GIT_SSH_KEY", "/etc/git-secret/ssh"),
+var flSSHKeyFile = flag.String("ssh-key-file", envString("GIT_SSH_KEY_FILE", "/etc/git-secret/ssh"),
 	"the ssh key to use")
 var flSSHKnownHosts = flag.Bool("ssh-known-hosts", envBool("GIT_KNOWN_HOSTS", true),
 	"enable SSH known_hosts verification")
-var flSSHKnownHostsFile = flag.String("ssh-known-hosts-file", envString("GIT_KNOWN_HOSTS_FILE", "/etc/git-secret/known_hosts"),
+var flSSHKnownHostsFile = flag.String("ssh-known-hosts-file", envString("GIT_SSH_KNOWN_HOSTS_FILE", "/etc/git-secret/known_hosts"),
 	"the known hosts file to use")
 
 var flCookieFile = flag.Bool("cookie-file", envBool("GIT_COOKIE_FILE", false),

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -69,7 +69,7 @@ var flPassword = flag.String("password", envString("GIT_SYNC_PASSWORD", ""),
 
 var flSSH = flag.Bool("ssh", envBool("GIT_SYNC_SSH", false),
 	"use SSH for git operations")
-var flSSHSecret = flag.String("ssh-key", envString("GIT_SSH_KEY", "/etc/git-secret/ssh"),
+var flSSHKeyFile = flag.String("ssh-key-file", envString("GIT_SSH_KEY", "/etc/git-secret/ssh"),
 	"the ssh key to use")
 var flSSHKnownHosts = flag.Bool("ssh-known-hosts", envBool("GIT_KNOWN_HOSTS", true),
 	"enable SSH known_hosts verification")
@@ -517,7 +517,7 @@ func setupGitAuth(username, password, gitURL string) error {
 func setupGitSSH(setupKnownHosts bool) error {
 	log.V(1).Infof("setting up git SSH credentials")
 
-	var pathToSSHSecret = *flSSHSecret
+	var pathToSSHSecret = *flSSHKeyFile
 	var pathToSSHKnownHosts = *flSSHKnownHostsFile
 
 	fileInfo, err := os.Stat(pathToSSHSecret)


### PR DESCRIPTION
This simply moves the hard-coded values into flag options, with defaults being the options they were previously.