### PR TITLE
Add option to allow for unlimited failures

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -58,7 +58,7 @@ var flSyncTimeout = flag.Int("timeout", envInt("GIT_SYNC_TIMEOUT", 120),
 var flOneTime = flag.Bool("one-time", envBool("GIT_SYNC_ONE_TIME", false),
 	"exit after the initial checkout")
 var flMaxSyncFailures = flag.Int("max-sync-failures", envInt("GIT_SYNC_MAX_SYNC_FAILURES", 0),
-	"the number of consecutive failures allowed before aborting (the first pull must succeed, <0 allows for infinite failures)")
+	"the number of consecutive failures allowed before aborting (the first pull must succeed, -1 disables aborting for any number of failures after the initial sync)")
 var flChmod = flag.Int("change-permissions", envInt("GIT_SYNC_PERMISSIONS", 0),
 	"the file permissions to apply to the checked-out files")
 
@@ -189,7 +189,7 @@ func main() {
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(*flSyncTimeout))
 		if err := syncRepo(ctx, *flRepo, *flBranch, *flRev, *flDepth, *flRoot, *flDest); err != nil {
-			if initialSync || (*flMaxSyncFailures >= 0 && failCount >= *flMaxSyncFailures) {
+			if initialSync || (*flMaxSyncFailures != -1 && failCount >= *flMaxSyncFailures) {
 				log.Errorf("error syncing repo: %v", err)
 				os.Exit(1)
 			}

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -58,7 +58,7 @@ var flSyncTimeout = flag.Int("timeout", envInt("GIT_SYNC_TIMEOUT", 120),
 var flOneTime = flag.Bool("one-time", envBool("GIT_SYNC_ONE_TIME", false),
 	"exit after the initial checkout")
 var flMaxSyncFailures = flag.Int("max-sync-failures", envInt("GIT_SYNC_MAX_SYNC_FAILURES", 0),
-	"the number of consecutive failures allowed before aborting (the first pull must succeed)")
+	"the number of consecutive failures allowed before aborting (the first pull must succeed, <0 allows for infinite failures)")
 var flChmod = flag.Int("change-permissions", envInt("GIT_SYNC_PERMISSIONS", 0),
 	"the file permissions to apply to the checked-out files")
 
@@ -189,7 +189,7 @@ func main() {
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*time.Duration(*flSyncTimeout))
 		if err := syncRepo(ctx, *flRepo, *flBranch, *flRev, *flDepth, *flRoot, *flDest); err != nil {
-			if initialSync || failCount >= *flMaxSyncFailures {
+			if initialSync || (*flMaxSyncFailures >= 0 && failCount >= *flMaxSyncFailures) {
 				log.Errorf("error syncing repo: %v", err)
 				os.Exit(1)
 			}


### PR DESCRIPTION
As it stands today git-sync will exit (which will in-turn cause the pod to die) if a git pull fails a number of times. If this failure was due to a remote (such as the git remote being unavailable, such as a github outage) it may be undesirable for your pods to churn. This add the option for the user to define `-1` as the failure limit which allows git-sync to retry indefinitely.