### PR TITLE
Use depth option when doing fetches

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -339,11 +339,22 @@ func updateSymlink(ctx context.Context, gitRoot, link, newDir string) error {
 }
 
 // addWorktreeAndSwap creates a new worktree and calls updateSymlink to swap the symlink to point to the new worktree
-func addWorktreeAndSwap(ctx context.Context, gitRoot, dest, branch, rev, hash string) error {
+func addWorktreeAndSwap(ctx context.Context, gitRoot, dest, branch, rev string, depth int, hash string) error {
 	log.V(0).Infof("syncing to %s (%s)", rev, hash)
 
+	args := []string{"fetch", "--tags"}
+	if depth != 0 {
+		args = append(args, "--depth", strconv.Itoa(depth))
+	}
+	args = append(args, "origin", branch)
+
 	// Update from the remote.
-	if _, err := runCommand(ctx, gitRoot, *flGitCmd, "fetch", "--tags", "origin", branch); err != nil {
+	if _, err := runCommand(ctx, gitRoot, *flGitCmd, args...); err != nil {
+		return err
+	}
+
+	// GC clone
+	if _, err := runCommand(ctx, gitRoot, *flGitCmd, "gc", "--prune=all"); err != nil {
 		return err
 	}
 
@@ -469,7 +480,7 @@ func syncRepo(ctx context.Context, repo, branch, rev string, depth int, gitRoot,
 		}
 	}
 
-	return true, addWorktreeAndSwap(ctx, gitRoot, dest, branch, rev, hash)
+	return true, addWorktreeAndSwap(ctx, gitRoot, dest, branch, rev, depth, hash)
 }
 
 // getRevs returns the local and upstream hashes for rev.

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -536,6 +536,8 @@ assert_link_exists "$ROOT"/link
 assert_file_exists "$ROOT"/link/file
 assert_file_eq "$ROOT"/link/file "$TESTCASE 2"
 # Wrap up
+remove_sync_container
+wait
 pass
 
 # Test depth syncing


### PR DESCRIPTION
Previously the `depth` flag was only used for the initial clone-- so
although you might start with a depth=10 as more commits show up you are
always >10. With this diff we enforce that depth on each fetch, this way
old-commits can get GCd off to reduce the size of the local checkout
required.

Related to #54