### PR TITLE
Use debian-base as base image

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -18,14 +18,16 @@ MAINTAINER Tim Hockin <thockin@google.com>
 
 ADD bin/{ARG_OS}_{ARG_ARCH}/{ARG_BIN} /{ARG_BIN}
 
-RUN apk update --no-cache && apk add \
-    ca-certificates \
-    coreutils \
-    git \
-    openssh-client
+RUN apt-get update \
+    && apt-get -y install \
+        ca-certificates \
+        coreutils \
+        git \
+        openssh-client \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN echo "git-sync:x:65533:65533::/tmp:/sbin/nologin" >> /etc/passwd
 
 WORKDIR /tmp
-USER git-sync:nobody
+USER git-sync:nogroup
 ENTRYPOINT ["/{ARG_BIN}"]

--- a/Makefile
+++ b/Makefile
@@ -33,27 +33,13 @@ VERSION := $(shell git describe --tags --always --dirty)
 
 SRC_DIRS := cmd pkg # directories which hold app source (not vendored)
 
-ALL_PLATFORMS := linux/amd64
+ALL_PLATFORMS := linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x
 
 # Used internally.  Users should pass GOOS and/or GOARCH.
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 
-# TODO: get a baseimage that works for other platforms
-# linux/arm linux/arm64 linux/ppc64le
-
-# Set default base image dynamically for each arch
-ifeq ($(OS)/$(ARCH),linux/amd64)
-    BASEIMAGE ?= alpine:3.8
-#else ifeq ($(OS)/$(ARCH),linux/arm)
-#    BASEIMAGE ?= armel/busybox
-#else ifeq ($(OS)/$(ARCH),linux/arm64)
-#    BASEIMAGE ?= aarch64/busybox
-#else ifeq ($(OS)/$(ARCH),linux/ppc64le)
-#    BASEIMAGE ?= ppc64le/busybox
-else
-    $(error Unsupported target platform '$(OS)/$(ARCH)')
-endif
+BASEIMAGE ?= k8s.gcr.io/debian-base:0.4.1
 
 IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)__$(OS)_$(ARCH)


### PR DESCRIPTION
All of the main Kubernetes components are switching to it, since we can
maintain it more easily.