### PR TITLE
git-sync: removes special exit on first error

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -289,7 +289,8 @@ func main() {
 		if changed, err := syncRepo(ctx, *flRepo, *flBranch, *flRev, *flDepth, *flRoot, *flDest); err != nil {
 			syncDuration.WithLabelValues("error").Observe(time.Now().Sub(start).Seconds())
 			syncCount.WithLabelValues("error").Inc()
-			if initialSync || (*flMaxSyncFailures != -1 && failCount >= *flMaxSyncFailures) {
+			if *flMaxSyncFailures != -1 && failCount >= *flMaxSyncFailures {
+				// Exit after too many retries, maybe the error is not recoverable.
 				log.Error(err, "failed to sync repo, aborting")
 				os.Exit(1)
 			}


### PR DESCRIPTION
Old code used to exit at any error seen on first sync attempt.  This
didn't prove useful in practice, so removing that special case.

This may make git-sync slower to recover after user fixes a
non-retryable error, as now flMaxSyncFailures are needed before the pod
fails.  It may make sense in practice.

Fixes #161, in a different way than is proposed in PR #162.