### PR TITLE
exec: adds an option to log the command line

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -602,10 +602,12 @@ func runCommand(ctx context.Context, cwd, command string, args ...string) (strin
 	}
 	output, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
+		log.V(3).Info("command timed out", "err", err, "cwd", cwd, "cmd", cmdForLog(command, args...))
 		return "", fmt.Errorf("command timed out: %v: %q", err, string(output))
 
 	}
 	if err != nil {
+		log.V(3).Info("error running command", "err", err, "cwd", cwd, "cmd", cmdForLog(command, args...))
 		return "", fmt.Errorf("error running command: %v: %q", err, string(output))
 	}
 


### PR DESCRIPTION
Having a way to log the full command line that is actually being
executed is of huge help in debugging.  When we know what command
line failed, we have a chance to try and reproduce the error ourselves.

Calls to os/exec.Command{,Context} are moved to their own package to
provide a drop-in logging wrapper, but also to allow independent setting
of logging levels in pkg/exec through the use of --vmodule=...

Fixes #164.