### PR TITLE
Rebase against more recent k8s.gcr.io/debian-base image.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ALL_PLATFORMS := linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 
-BASEIMAGE ?= k8s.gcr.io/debian-base:0.4.1
+BASEIMAGE ?= k8s.gcr.io/debian-base:1.0.0
 
 IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)__$(OS)_$(ARCH)


### PR DESCRIPTION
This addresses several high-severity vulnerabilities that have been fixed:

CVE-2016-9841
CVE-2016-9843
CVE-2017-15670
CVE-2017-15804
CVE-2017-16997
CVE-2017-18269
CVE-2017-1000408
CVE-2018-11236
CVE-2018-20843
CVE-2019-3855