### PR TITLE
:sparkles: add submodules support

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -452,6 +452,14 @@ func addWorktreeAndSwap(ctx context.Context, gitRoot, dest, branch, rev string, 
 	}
 	log.V(0).Info("reset worktree to hash", "path", worktreePath, "hash", hash)
 
+	// Update submodules
+
+	_, err = runCommand(ctx, worktreePath, *flGitCmd, "submodule", "update", "--init", "--recursive")
+	if err != nil {
+		return err
+	}
+	log.V(0).Info("updating submodules")
+
 	if *flChmod != 0 {
 		// set file permissions
 		_, err = runCommand(ctx, "", "chmod", "-R", strconv.Itoa(*flChmod), worktreePath)

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -454,6 +454,9 @@ func addWorktreeAndSwap(ctx context.Context, gitRoot, dest, branch, rev string, 
 
 	// Update submodules
 	// NOTICE: it works for repos with or without submodules
+	// TODO: add --depth flag support
+	// possible bug in git: git fetches full submodule history even with --depth flag is provided
+	// (tested with git version 2.23.0 on Mac)
 	_, err = runCommand(ctx, worktreePath, *flGitCmd, "submodule", "update", "--init", "--recursive")
 	if err != nil {
 		return err

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -453,12 +453,12 @@ func addWorktreeAndSwap(ctx context.Context, gitRoot, dest, branch, rev string, 
 	log.V(0).Info("reset worktree to hash", "path", worktreePath, "hash", hash)
 
 	// Update submodules
-
+	// NOTICE: it works for repos with or without submodules
 	_, err = runCommand(ctx, worktreePath, *flGitCmd, "submodule", "update", "--init", "--recursive")
 	if err != nil {
 		return err
 	}
-	log.V(0).Info("updating submodules")
+	log.V(0).Info("updated submodules")
 
 	if *flChmod != 0 {
 		// set file permissions


### PR DESCRIPTION
This PR adds support for git submodules. Current code doesn't fetch submodules if such are present in git repository. Submodules are empty directories instead. We use `git-sync` in our project as a sidecar container for Apache Airflow and `git-sync` is responsible for shipping Airflow Dags code to Airflow webserver/workers. Git submodules support is really important for us, cause our current code repository heavily use submodules to demarcate different teams responsibilities. I've tested this patch on our Airflow instance and it works as expected. I hope that this PR will be useful for the community. 