### PR TITLE
Change git credential from cache to store and also add test for username/password case

### DIFF
--- a/askpass_git.sh
+++ b/askpass_git.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Ask pass when cloning new repo, fail if it mismatched the magic password.
+
+mkdir -p "${XDG_CONFIG_HOME}/git/"
+# Override the default 'git --global' config location, the default location
+# outside the e2e test environment. See https://git-scm.com/docs/git-config
+touch "${XDG_CONFIG_HOME}/git/config"
+# Override the default 'git credential store' config location, the default location
+# outside the e2e test environment. See https://git-scm.com/docs/git-credential-store
+touch "${XDG_CONFIG_HOME}/git/credentials"
+
+if [ "$1" != "clone" ]; then
+  git "$@"
+  exit $?
+fi
+
+REPO=$(echo "$@" | grep -o "file://[^ ]*")
+PASSWD=$(echo "url=${REPO}" | git credential fill | grep -o "password=.*")
+# Test case much match the magic password below.
+if [ "${PASSWD}" != "password=Lov3!k0os" ]; then
+  echo "invalid password ${PASSWD}, try Lov3!k0os next time."
+  exit 1
+fi
+
+git "$@"

--- a/askpass_git.sh
+++ b/askpass_git.sh
@@ -14,6 +14,8 @@ if [ "$1" != "clone" ]; then
   exit $?
 fi
 
+# `git credential fill` requires the repo url match to consume the credentials stored by git-sync.
+# Askpass git only support repo started with "file://" which is used in test_e2e.sh.
 REPO=$(echo "$@" | grep -o "file://[^ ]*")
 PASSWD=$(echo "url=${REPO}" | git credential fill | grep -o "password=.*")
 # Test case much match the magic password below.

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -693,7 +693,7 @@ func runCommandWithStdin(ctx context.Context, cwd, stdin, command string, args .
 }
 
 func setupGitAuth(ctx context.Context, username, password, gitURL string) error {
-	log.V(1).Info("setting up git credential cache")
+	log.V(1).Info("setting up git credential store")
 
 	_, err := runCommand(ctx, "", *flGitCmd, "config", "--global", "credential.helper", "store")
 	if err != nil {

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -695,7 +695,7 @@ func runCommandWithStdin(ctx context.Context, cwd, stdin, command string, args .
 func setupGitAuth(ctx context.Context, username, password, gitURL string) error {
 	log.V(1).Info("setting up git credential cache")
 
-	_, err := runCommand(ctx, "", *flGitCmd, "config", "--global", "credential.helper", "cache")
+	_, err := runCommand(ctx, "", *flGitCmd, "config", "--global", "credential.helper", "store")
 	if err != nil {
 		return fmt.Errorf("error setting up git credentials: %v", err)
 	}

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -637,14 +637,13 @@ GIT_SYNC \
     --password="I have no idea what the password is." \
     --logtostderr \
     --v=5 \
-    --wait=0.1 \
+    --one-time \
     --repo="file://$REPO" \
     --branch=master \
     --rev=HEAD \
     --root="$ROOT" \
     --dest="link" \
-    > "$DIR"/log."$TESTCASE" 2>&1 &
-sleep 3
+    > "$DIR"/log."$TESTCASE" 2>&1
 # check for failure
 assert_file_absent "$ROOT"/link/file
 # run with askpass_git with correct password
@@ -654,14 +653,13 @@ GIT_SYNC \
     --password="Lov3!k0os" \
     --logtostderr \
     --v=5 \
-    --wait=0.1 \
+    --one-time \
     --repo="file://$REPO" \
     --branch=master \
     --rev=HEAD \
     --root="$ROOT" \
     --dest="link" \
-    > "$DIR"/log."$TESTCASE" 2>&1 &
-sleep 3
+    > "$DIR"/log."$TESTCASE" 2>&1
 assert_link_exists "$ROOT"/link
 assert_file_exists "$ROOT"/link/file
 assert_file_eq "$ROOT"/link/file "$TESTCASE 1"

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -89,6 +89,8 @@ function GIT_SYNC() {
         -u $(id -u):$(id -g) \
         -v "$DIR":"$DIR" \
         -v "$(pwd)/slow_git.sh":"/slow_git.sh" \
+        -v "$(pwd)/askpass_git.sh":"/askpass_git.sh" \
+        --env XDG_CONFIG_HOME=$DIR \
         --network="host" \
         --rm \
         e2e/git-sync:$(make -s version)__$(go env GOOS)_$(go env GOARCH) \
@@ -102,6 +104,7 @@ function remove_sync_container() {
 }
 
 SLOW_GIT=/slow_git.sh
+ASKPASS_GIT=/askpass_git.sh
 
 REPO="$DIR/repo"
 mkdir "$REPO"
@@ -622,6 +625,52 @@ wait
 pass
 
 ##############################################
+# Test password
+##############################################
+testcase "password"
+echo "$TESTCASE 1" > "$REPO"/file
+git -C "$REPO" commit -qam "$TESTCASE 1"
+# run with askpass_git but with wrong password
+GIT_SYNC \
+    --git=$ASKPASS_GIT \
+    --username="you@example.com" \
+    --password="I have no idea what the password is." \
+    --logtostderr \
+    --v=5 \
+    --wait=0.1 \
+    --repo="file://$REPO" \
+    --branch=master \
+    --rev=HEAD \
+    --root="$ROOT" \
+    --dest="link" \
+    > "$DIR"/log."$TESTCASE" 2>&1 &
+sleep 3
+# check for failure
+assert_file_absent "$ROOT"/link/file
+# run with askpass_git with correct password
+GIT_SYNC \
+    --git=$ASKPASS_GIT \
+    --username="you@example.com" \
+    --password="Lov3!k0os" \
+    --logtostderr \
+    --v=5 \
+    --wait=0.1 \
+    --repo="file://$REPO" \
+    --branch=master \
+    --rev=HEAD \
+    --root="$ROOT" \
+    --dest="link" \
+    > "$DIR"/log."$TESTCASE" 2>&1 &
+sleep 3
+assert_link_exists "$ROOT"/link
+assert_file_exists "$ROOT"/link/file
+assert_file_eq "$ROOT"/link/file "$TESTCASE 1"
+# Wrap up
+remove_sync_container
+wait
+pass
+
+##############################################
 # Test webhook
 ##############################################
 testcase "webhook"
@@ -788,7 +837,7 @@ assert_file_absent "$ROOT"/link/$SUBMODULE_REPO_NAME/$NESTED_SUBMODULE_REPO_NAME
 # Remove submodule
 git -C "$REPO" submodule deinit -q $SUBMODULE_REPO_NAME
 rm -rf "$REPO"/.git/modules/$SUBMODULE_REPO_NAME
-git -C "$REPO" rm -qf $SUBMODULE_REPO_NAME 
+git -C "$REPO" rm -qf $SUBMODULE_REPO_NAME
 git -C "$REPO" commit -aqm "delete submodule"
 sleep 3
 assert_link_exists "$ROOT"/link

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -643,7 +643,7 @@ GIT_SYNC \
     --rev=HEAD \
     --root="$ROOT" \
     --dest="link" \
-    > "$DIR"/log."$TESTCASE" 2>&1
+    > "$DIR"/log."$TESTCASE" 2>&1 || true
 # check for failure
 assert_file_absent "$ROOT"/link/file
 # run with askpass_git with correct password
@@ -664,8 +664,6 @@ assert_link_exists "$ROOT"/link
 assert_file_exists "$ROOT"/link/file
 assert_file_eq "$ROOT"/link/file "$TESTCASE 1"
 # Wrap up
-remove_sync_container
-wait
 pass
 
 ##############################################


### PR DESCRIPTION
For cache to store change:
* By default, `cache` only last 900 seconds, gitsync will break after
  that for password setup. See https://git-scm.com/docs/git-credential-cache.
* The test won't work with cache since the test don't have access to
  the default unix socket location; XDG_CACHE_HOME override also cann't
  pre-create a socket in advance.
* `store` put the credential into a file, much easier to debug than cache.
* Considering anyone have access to the pod already able to get the
  credential via environment variables or yaml configs, so put it in
  file won't make it less secure.

For the new password test:
*  `askpass_git.sh` provided to simulate a git with password challenge.
*  Need and only need to challenge for "clone" action. Need to bypass all the other
  actions like config/credential setup.
*  See `credential fill` is the official git action to ask password,
  see https://git-scm.com/docs/git-credential.

Fixes #196.