### PR TITLE
Support ssh as arbitrary users, add e2e for SSH

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -22,7 +22,11 @@ RUN apt-get update \
         openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
+# By default we will run as this user...
 RUN echo "git-sync:x:65533:65533::/tmp:/sbin/nologin" >> /etc/passwd
+# ...but the user might choose a different UID and pass --add-user
+# which needs to be able to write to /etc/passwd.
+RUN chmod 0666 /etc/passwd
 
 ADD bin/{ARG_OS}_{ARG_ARCH}/{ARG_BIN} /{ARG_BIN}
 

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,9 @@ test: $(BUILD_DIRS)
 	    "
 	@./test_e2e.sh
 
+test-tools:
+	@docker build -t $(REGISTRY)/test/test-sshd _test_tools/sshd
+
 $(BUILD_DIRS):
 	@mkdir -p $@
 

--- a/_test_tools/sshd/Dockerfile
+++ b/_test_tools/sshd/Dockerfile
@@ -1,0 +1,39 @@
+# Stolen from https://github.com/linuxkit/linuxkit/tree/master/pkg/sshd/
+
+FROM alpine AS base
+
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    apk-tools \
+    busybox \
+    ca-certificates \
+    git \
+    musl \
+    openssh-server \
+    tini \
+    util-linux \
+    wireguard-tools \
+    && true
+
+###############
+
+FROM scratch
+
+ENTRYPOINT []
+WORKDIR /
+
+COPY --from=base /out/ /
+
+RUN mkdir -p /etc/ssh && rm /etc/motd
+COPY sshd_config /etc/ssh/
+COPY sshd.sh /
+
+# Callers should mount a .ssh directory here. Our sshd.sh will copy it and
+# manage permissions.
+VOLUME /dot_ssh
+
+# Callers can SSH as user "test"
+RUN echo "test:x:65533:65533::/home/test:/usr/bin/git-shell" >> /etc/passwd
+
+CMD ["/sbin/tini", "/sshd.sh"]

--- a/_test_tools/sshd/README.md
+++ b/_test_tools/sshd/README.md
@@ -1,0 +1,52 @@
+# An SSHD for tests git-over-ssh
+
+DO NOT USE THIS FOR ANYTHING BUT TESTING GIT OVER SSH!!!
+
+## How to use it
+
+Build yourself a test image.  We use example.com so you can't accidentally push
+it.
+
+```
+$ docker build -t example.com/test/test-sshd .
+...lots of output...
+Successfully tagged example.com/test/test-sshd:latest
+```
+
+Generate keys for a fake user named "test".
+
+```
+$ mkdir -p dot_ssh
+
+$ ssh-keygen -f dot_ssh/id_test -P ""
+Generating public/private rsa key pair.
+Your identification has been saved in dot_ssh/id_test.
+Your public key has been saved in dot_ssh/id_test.pub.
+...lots of output...
+
+$ cat dot_ssh/id_test.pub > dot_ssh/authorized_keys
+```
+
+Run it.
+
+```
+$ docker run -d -v $(pwd)/dot_ssh:/dot_ssh:ro example.com/test/test-sshd
+6d05b4111b03c66907031e3cd7587763f0e4fab6c50fac33c4a8284732b448ae
+```
+
+Find your IP.
+
+```
+$ docker inspect 6d05b4111b03c66907031e3cd7587763f0e4fab6c50fac33c4a8284732b448ae | jq -r .[0].NetworkSettings.IPAddress
+192.168.1.2
+```
+
+SSH to it.
+
+```
+$ ssh -i dot_ssh/id_test -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null test@192.168.9.2
+Warning: Permanently added '192.168.9.2' (ECDSA) to the list of known hosts.
+fatal: Interactive git shell is not enabled.
+hint: ~/git-shell-commands should exist and have read and execute access.
+Connection to 192.168.9.2 closed.
+```

--- a/_test_tools/sshd/sshd.sh
+++ b/_test_tools/sshd/sshd.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+KEYS=$(find /etc/ssh -name 'ssh_host_*_key')
+[ -z "$KEYS" ] && ssh-keygen -A >/dev/null 2>/dev/null
+
+# Copy creds for the test user, so we don't have to bake them into the image
+# and so users don't have to manage permissions.
+mkdir -p /home/test/.ssh
+cp -a /dot_ssh/* /home/test/.ssh
+chown -R test /home/test/.ssh
+chmod 0700 /home/test/.ssh
+chmod 0600 /home/test/.ssh/*
+
+exec /usr/sbin/sshd -D -e

--- a/_test_tools/sshd/sshd_config
+++ b/_test_tools/sshd/sshd_config
@@ -1,0 +1,12 @@
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
+
+# To disable tunneled clear text passwords, change to no here!
+PasswordAuthentication no
+
+# Change to no to disable s/key passwords
+ChallengeResponseAuthentication no

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -103,6 +103,11 @@ that this is a Pod-wide setting, unlike the container `securityContext` above.
       # ...
 ```
 
+If you want git-sync to run as a different (non-root) UID and GID, you can
+change these last blocks to any UID/GID you like.  SSH demands that the current
+UID be present in /etc/passwd, so in this case you will need to add the
+`--add-user` flag to git-sync's args array.
+
 **Note:** Kubernetes mounts the Secret with permissions 0444 by default (not
 restrictive enough to be used as an SSH key), so make sure you set the
 `defaultMode`.

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -62,7 +62,7 @@ Secret (e.g. "git-creds" used in both above examples).
       - name: git-secret
         secret:
           secretName: git-creds
-          defaultMode: 288 # 0440
+          defaultMode: 0400
       # ...
 ```
 
@@ -135,7 +135,7 @@ spec:
       - name: git-secret
         secret:
           secretName: git-creds
-          defaultMode: 0440
+          defaultMode: 0400
       containers:
       - name: git-sync
         image: k8s.gcr.io/git-sync:v3.1.1


### PR DESCRIPTION
This adds a --add-user flag to write UID and GID to /etc/passwd, and then adds a test for `--ssh`.  Hopefully this can be a blueprint for other test cases.

Fixes #176 

Fixes #195 

Fixes #215 