### PR TITLE
Bump to debian-base 2.0.0 (buster)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ALL_PLATFORMS := linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 
-BASEIMAGE ?= k8s.gcr.io/debian-base:1.0.0
+BASEIMAGE ?= k8s.gcr.io/debian-base:v2.0.0
 
 IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)__$(OS)_$(ARCH)

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -480,7 +480,7 @@ func setRepoReady() {
 func addWorktreeAndSwap(ctx context.Context, gitRoot, dest, branch, rev string, depth int, hash string) error {
 	log.V(0).Info("syncing git", "rev", rev, "hash", hash)
 
-	args := []string{"fetch", "--tags"}
+	args := []string{"fetch", "-f", "--tags"}
 	if depth != 0 {
 		args = append(args, "--depth", strconv.Itoa(depth))
 	}

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -995,6 +995,7 @@ CTR=$(docker run \
     -v "$DOT_SSH":/dot_ssh:ro \
     -v "$REPO":/src:ro \
     e2e/test/test-sshd)
+sleep 3 # wait for sshd to come up
 IP=$(docker inspect "$CTR" | jq -r .[0].NetworkSettings.IPAddress)
 git -C "$REPO" commit -qam "$TESTCASE"
 GIT_SYNC \


### PR DESCRIPTION
This changed `git fetch` to require a `-f` the way we use it.

Also fix a flaky test case for SSH.

Fixes #229