### PR TITLE
Fixed Docker image tag in SSH documentation page

### DIFF
--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -79,7 +79,7 @@ as user ID "65533" which is created for running git-sync as non-root.
       # ...
       containers:
       - name: git-sync
-        image: k8s.gcr.io/git-sync:v9.3.76
+        image: k8s.gcr.io/git-sync:v3.1.5
         args:
          - "-ssh"
          - "-repo=git@github.com:foo/bar"
@@ -138,7 +138,7 @@ spec:
           defaultMode: 0400
       containers:
       - name: git-sync
-        image: k8s.gcr.io/git-sync:v3.1.1
+        image: k8s.gcr.io/git-sync:v3.1.5
         args:
          - "-ssh"
          - "-repo=git@github.com:torvalds/linux"


### PR DESCRIPTION
Just updating both Docker image tags in [`docs/ssh.md`](https://github.com/kubernetes/git-sync/blob/master/docs/ssh.md) to the latest version.