### PR TITLE
use uid,gid instead of username and groupname

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -32,5 +32,5 @@ RUN chmod 0666 /etc/passwd
 ADD bin/{ARG_OS}_{ARG_ARCH}/{ARG_BIN} /{ARG_BIN}
 
 WORKDIR /tmp
-USER git-sync:nogroup
+USER 65533:65533
 ENTRYPOINT ["/{ARG_BIN}"]


### PR DESCRIPTION
Many Pod security policies expect  the container to run with  numeric user , so that it can verify if the container is running with a non-root user(!=0)

Updating the dockerfile to use the numeric equivalent of the git-sync user