### PR TITLE
add an option to source password from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ docker run -d \
 | GIT_SYNC_WEBHOOK_BACKOFF        | `--webhook-backoff`        | the time to wait before retrying a failed webhook                                                                                      | 3 (seconds)                   |
 | GIT_SYNC_USERNAME               | `--username`               | the username to use for git auth                                                                                                       | ""                            |
 | GIT_SYNC_PASSWORD               | `--password`               | the password to use for git auth (users should prefer env vars for passwords)                                                          | ""                            |
+| GIT_SYNC_PASSWORD_FILE          | `--password-file`          | the file form which the password for git auth has to be sourced.                                                                        | ""                            |
+
 | GIT_SYNC_SSH                    | `--ssh`                    | use SSH for git operations                                                                                                             | false                         |
 | GIT_SSH_KEY_FILE                | `--ssh-key-file`           | the SSH key to use                                                                                                                     | "/etc/git-secret/ssh"         |
 | GIT_KNOWN_HOSTS                 | `--ssh-known-hosts`        | enable SSH known_hosts verification                                                                                                    | true                          |


### PR DESCRIPTION
Adding an option to source the git password from a file . This will help in cases where the password can be injected as a file using say Hashicorp vault injector