### PR TITLE
Multiarch via buildx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.push-*
 /.container-*
 /.dockerfile-*
+/.qemu-initialized

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -15,6 +15,7 @@
 FROM {ARG_FROM}
 
 RUN apt-get update \
+    && apt-get -y upgrade \
     && apt-get -y install \
         ca-certificates \
         coreutils \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ BASEIMAGE ?= k8s.gcr.io/debian-base:v2.0.0
 IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)__$(OS)_$(ARCH)
 
-BUILD_IMAGE ?= golang:1.13-alpine
+BUILD_IMAGE ?= golang:1.14-alpine
 
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-container' rule.


### PR DESCRIPTION
We'll probably want to cut a 3.1.7 for this.  Test build is up at thockin/git-sync:v3.1.6-dirty__linux_arm64 and manifest at  thockin/git-sync:v3.1.6-dirty.

Fixes #222 