### PR TITLE
README: add buildx comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ synchronization. The call is made after the symlink is updated.
 
 ## Building it
 
+We use [docker buildx](https://github.com/docker/buildx) to build images.
+
 ```
 # build the container
 make container REGISTRY=registry VERSION=tag


### PR DESCRIPTION
Signed-off-by: Xiang Dai <long0dai@foxmail.com>

Without `docker buildx`:
```
root:[git-sync]$ make container
making bin/linux_amd64/git-sync
Unable to find image 'golang:1.14-alpine' locally
1.14-alpine: Pulling from library/golang
188c0c94c7c5: Pull complete
0ef7d3d256c8: Pull complete
de9db76c5a1d: Pull complete
cdb4a6b39b2d: Pull complete
15a9bb109214: Pull complete
Digest: sha256:0e691cd2b47d20f0c5b4ce55385b9d02fb9c66b78dcbaa4ce5a56d41b1c16491
Status: Downloaded newer image for golang:1.14-alpine
unknown flag: --load
See 'docker --help'.

Usage:	docker [OPTIONS] COMMAND
```