### PR TITLE
Change time-related flags to durations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker run -d \
     registry/git-sync:tag \
         --repo=https://github.com/kubernetes/git-sync \
         --branch=master \
-        --wait=30
+        --period=30s
 
 # run an nginx container to serve the content
 docker run -d \
@@ -74,7 +74,7 @@ docker run -d \
     registry/git-sync:tag \
         --repo=https://github.com/kubernetes/git-sync \
         --branch=master \
-        --wait=30 \
+        --period=30s \
         --webhook-url="http://localhost:9090/-/reload"
 ```
 
@@ -89,8 +89,8 @@ docker run -d \
 | GIT_SYNC_SUBMODULES             | `--submodules`             | git submodule behavior: one of 'recursive', 'shallow', or 'off'                                                                                                                                                                               | recursive                     |
 | GIT_SYNC_ROOT                   | `--root`                   | the root directory for git-sync operations, under which --dest will be created                                                                                                                                                                | "$HOME/git"                   |
 | GIT_SYNC_DEST                   | `--dest`                   | the name of (a symlink to) a directory in which to check-out files under --root (defaults to the leaf dir of --repo)                                                                                                                          | ""                            |
-| GIT_SYNC_WAIT                   | `--wait`                   | the number of seconds between syncs                                                                                                                                                                                                           | 1 (second)                    |
-| GIT_SYNC_TIMEOUT                | `--timeout`                | the max number of seconds allowed for a complete sync                                                                                                                                                                                         | 120                           |
+| GIT_SYNC_PERIOD                 | `--period`                 | how long to wait between syncs, must be >= 10ms                                                                                                                                                                                               | "10s"                         |
+| GIT_SYNC_SYNC_TIMEOUT           | `--sync-timeout`           | the total time allowed for one complete sync, must be >= 10ms                                                                                                                                                                                 | "120s"                        |
 | GIT_SYNC_ONE_TIME               | `--one-time`               | exit after the first sync                                                                                                                                                                                                                     | false                         |
 | GIT_SYNC_MAX_SYNC_FAILURES      | `--max-sync-failures`      | the number of consecutive failures allowed before aborting (the first sync must succeed, -1 will retry forever after the initial sync)                                                                                                        | 0                             |
 | GIT_SYNC_PERMISSIONS            | `--change-permissions`     | the file permissions to apply to the checked-out files (0 will not change permissions at all)                                                                                                                                                 | 0                             |

--- a/cmd/git-sync/webhook.go
+++ b/cmd/git-sync/webhook.go
@@ -81,7 +81,7 @@ func (w *Webhook) Do(hash string) error {
 	defer cancel()
 	req = req.WithContext(ctx)
 
-	log.V(0).Info("sending webhook", "hash", hash, "url", w.URL, "method", w.Method, "timeout", w.Timeout)
+	log.V(0).Info("sending webhook", "hash", hash, "url", w.URL, "method", w.Method, "timeout", w.Timeout.String())
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
@@ -113,7 +113,7 @@ func (w *Webhook) run() {
 			}
 
 			if err := w.Do(hash); err != nil {
-				log.Error(err, "webhook failed", "url", w.URL, "method", w.Method, "timeout", w.Timeout)
+				log.Error(err, "webhook failed", "url", w.URL, "method", w.Method, "timeout", w.Timeout.String())
 				time.Sleep(w.Backoff)
 			} else {
 				lastHash = hash

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -172,7 +172,7 @@ testcase "default-sync"
 echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --root="$ROOT" \
     --dest="link" \
@@ -205,7 +205,7 @@ testcase "head-sync"
 echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --branch=master \
     --rev=HEAD \
@@ -243,7 +243,7 @@ echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
 git -C "$REPO" checkout -q master
 GIT_SYNC \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --branch="$BRANCH" \
     --root="$ROOT" \
@@ -283,7 +283,7 @@ echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
 git -C "$REPO" tag -f "$TAG" >/dev/null
 GIT_SYNC \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --rev="$TAG" \
     --root="$ROOT" \
@@ -328,7 +328,7 @@ echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
 git -C "$REPO" tag -af "$TAG" -m "$TESTCASE 1" >/dev/null
 GIT_SYNC \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --rev="$TAG" \
     --root="$ROOT" \
@@ -372,7 +372,7 @@ echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
 REV=$(git -C "$REPO" rev-list -n1 HEAD)
 GIT_SYNC \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --rev="$REV" \
     --root="$ROOT" \
@@ -460,7 +460,7 @@ git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
     --git="$SLOW_GIT" \
     --one-time \
-    --timeout=1 \
+    --sync-timeout=1s \
     --repo="file://$REPO" \
     --root="$ROOT" \
     --dest="link" \
@@ -470,8 +470,8 @@ assert_file_absent "$ROOT"/link/file
 # run with slow_git but without timing out
 GIT_SYNC \
     --git="$SLOW_GIT" \
-    --wait=0.1 \
-    --timeout=16 \
+    --period=100ms \
+    --sync-timeout=16s \
     --repo="file://$REPO" \
     --root="$ROOT" \
     --dest="link" \
@@ -499,7 +499,7 @@ echo "$TESTCASE 1" > "$REPO"/file
 expected_depth="1"
 git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --depth="$expected_depth" \
     --root="$ROOT" \
@@ -634,7 +634,7 @@ testcase "sync_hook_command"
 echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --root="$ROOT" \
     --dest="link" \
@@ -667,6 +667,7 @@ freencport
 echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
+    --period=100ms \
     --repo="file://$REPO" \
     --root="$ROOT" \
     --webhook-url="http://127.0.0.1:$NCPORT" \
@@ -709,6 +710,7 @@ freencport
 echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
+    --period=100ms \
     --repo="file://$REPO" \
     --root="$ROOT" \
     --webhook-url="http://127.0.0.1:$NCPORT" \
@@ -735,6 +737,7 @@ echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
     --git="$SLOW_GIT" \
+    --period=100ms \
     --repo="file://$REPO" \
     --root="$ROOT" \
     --http-bind=":$BINDPORT" \
@@ -795,7 +798,7 @@ git -C "$NESTED_SUBMODULE" commit -aqm "init nested-submodule file"
 git -C "$REPO" submodule add -q file://$SUBMODULE
 git -C "$REPO" commit -aqm "add submodule"
 GIT_SYNC \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --root="$ROOT" \
     --dest="link" \
@@ -882,7 +885,7 @@ git -C "$REPO" submodule add -q file://$SUBMODULE
 git -C "$REPO" config -f "$REPO"/.gitmodules submodule.$SUBMODULE_REPO_NAME.shallow true
 git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --depth="$expected_depth" \
     --root="$ROOT" \
@@ -957,11 +960,11 @@ git -C "$REPO" submodule add -q file://$SUBMODULE
 git -C "$REPO" commit -aqm "add submodule"
 
 GIT_SYNC \
-    --submodules=off \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --root="$ROOT" \
     --dest="link" \
+    --submodules=off \
     > "$DIR"/log."$TESTCASE" 2>&1 &
 sleep 3
 assert_file_absent "$ROOT"/link/$SUBMODULE_REPO_NAME/submodule
@@ -999,11 +1002,11 @@ git -C "$REPO" submodule add -q file://$SUBMODULE
 git -C "$REPO" commit -aqm "add submodule"
 
 GIT_SYNC \
-    --submodules=shallow \
-    --wait=0.1 \
+    --period=100ms \
     --repo="file://$REPO" \
     --root="$ROOT" \
     --dest="link" \
+    --submodules=shallow \
     > "$DIR"/log."$TESTCASE" 2>&1 &
 sleep 3
 assert_link_exists "$ROOT"/link
@@ -1032,13 +1035,13 @@ IP=$(docker inspect "$CTR" | jq -r .[0].NetworkSettings.IPAddress)
 git -C "$REPO" commit -qam "$TESTCASE"
 GIT_SYNC \
     --one-time \
-    --ssh \
-    --ssh-known-hosts=false \
     --repo="test@$IP:/src" \
     --branch=master \
     --rev=HEAD \
     --root="$ROOT" \
     --dest="link" \
+    --ssh \
+    --ssh-known-hosts=false \
     > "$DIR"/log."$TESTCASE" 2>&1
 assert_link_exists "$ROOT"/link
 assert_file_exists "$ROOT"/link/file


### PR DESCRIPTION
Builds on #298 

Add '--period' to replace '--wait', which is now obsolete.
    
Add '--sync-timeout' to replace '--timeout', which is now obsolete.
    
Both of these new flags take a Go-style time string, rather than a bare
number. For example "1s" for 1 second or "1m" for one minute.
    
The old flags have been kept and will take precedence if specified.

xref #297 
