### PR TITLE
Allow octal and hex values for int flags

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -180,12 +180,12 @@ func envBool(key string, def bool) bool {
 
 func envInt(key string, def int) int {
 	if env := os.Getenv(key); env != "" {
-		val, err := strconv.Atoi(env)
+		val, err := strconv.ParseInt(env, 0, 0)
 		if err != nil {
 			log.Error(err, "invalid env value, using default", "key", key, "val", os.Getenv(key), "default", def)
 			return def
 		}
-		return val
+		return int(val)
 	}
 	return def
 }


### PR DESCRIPTION
This is specifcally relevant to --change-permissions.

Fixes #320