### PR TITLE
Use docker to run helper servers in e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ test: $(BUILD_DIRS)
 
 test-tools:
 	@docker build -t $(REGISTRY)/test/test-sshd _test_tools/sshd
+	@docker build -t $(REGISTRY)/test/test-ncsvr _test_tools/ncsvr
 
 # Help set up multi-arch build tools.  This assumes you have the tools
 # installed.  If you already have a buildx builder available, you don't need

--- a/_test_tools/ncsvr/Dockerfile
+++ b/_test_tools/ncsvr/Dockerfile
@@ -1,0 +1,25 @@
+# Stolen from https://github.com/linuxkit/linuxkit/tree/master/pkg/sshd/
+
+FROM alpine AS base
+
+RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
+RUN apk add --no-cache --initdb -p /out \
+    alpine-baselayout \
+    apk-tools \
+    busybox \
+    util-linux \
+    netcat-openbsd \
+    && true
+
+###############
+
+FROM scratch
+
+ENTRYPOINT []
+WORKDIR /
+
+COPY --from=base /out/ /
+
+COPY ncsvr.sh /
+
+ENTRYPOINT ["/ncsvr.sh"]

--- a/_test_tools/ncsvr/README.md
+++ b/_test_tools/ncsvr/README.md
@@ -1,0 +1,38 @@
+# A simple server for tests
+
+DO NOT USE THIS FOR ANYTHING BUT TESTING!!!
+
+## How to use it
+
+Build yourself a test image.  We use example.com so you can't accidentally push
+it.
+
+```
+$ docker build -t example.com/test/test-ncvsr .
+...lots of output...
+Successfully tagged example.com/test/test-ncsvr:latest
+```
+
+Run it.
+
+```
+$ docker run -d example.com/test/test-ncsvr 9376 "echo hello"
+6d05b4111b03c66907031e3cd7587763f0e4fab6c50fac33c4a8284732b448ae
+```
+
+Find your IP.
+
+```
+$ docker inspect 6d05b4111b03c66907031e3cd7587763f0e4fab6c50fac33c4a8284732b448ae | jq -r .[0].NetworkSettings.IPAddress
+192.168.1.2
+```
+
+Connect to it.
+
+```
+$ echo "" | nc 192.168.9.2 9376
+hello
+```
+
+If you want to know how many times it was accessed, mount a file on
+/var/log/hits.  This will log one line per hit.

--- a/_test_tools/ncsvr/ncsvr.sh
+++ b/_test_tools/ncsvr/ncsvr.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ -z "$1" -o -z "$2" ]; then
+    echo "usage: $0 <port> <shell-command>"
+    exit 1
+fi
+
+while true; do
+    sh -c "$2" | nc -l -p "$1" -N -w0 >/dev/null
+    date >> /var/log/hits
+done

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -105,7 +105,7 @@ REPO="$DIR/repo"
 function init_repo() {
     rm -rf "$REPO"
     mkdir -p "$REPO"
-    git -C "$REPO" init -q -b master
+    git -C "$REPO" init -q -b e2e-branch
     touch "$REPO"/file
     git -C "$REPO" add file
     git -C "$REPO" commit -aqm "init file"
@@ -175,7 +175,7 @@ rm -rf "$ROOT" # remove the root to test
 GIT_SYNC \
     --one-time \
     --repo="file://$REPO" \
-    --branch=master \
+    --branch=e2e-branch \
     --rev=HEAD \
     --root="$ROOT" \
     --link="link" \
@@ -195,7 +195,7 @@ git -C "$REPO" commit -qam "$TESTCASE"
 GIT_SYNC \
     --one-time \
     --repo="file://$REPO" \
-    --branch=master \
+    --branch=e2e-branch \
     --rev=HEAD \
     --root="$ROOT" \
     --link="link" \
@@ -215,7 +215,7 @@ git -C "$REPO" commit -qam "$TESTCASE"
 GIT_SYNC \
     --one-time \
     --repo="file://$REPO" \
-    --branch=master \
+    --branch=e2e-branch \
     --rev=HEAD \
     --root="../../../../../$ROOT/../../../../../../$ROOT" \
     --link="link" \
@@ -236,7 +236,7 @@ ln -s "$ROOT" "$DIR/rootlink" # symlink to test
 GIT_SYNC \
     --one-time \
     --repo="file://$REPO" \
-    --branch=master \
+    --branch=e2e-branch \
     --rev=HEAD \
     --root="$DIR/rootlink" \
     --link="link" \
@@ -248,12 +248,13 @@ assert_file_eq "$ROOT"/link/file "$TESTCASE"
 pass
 
 ##############################################
-# Test default syncing
+# Test default syncing (master)
 ##############################################
-testcase "default-sync"
+testcase "default-sync-master"
 # First sync
 echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
+git -C "$REPO" checkout -q -b master
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
@@ -290,7 +291,7 @@ git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
-    --branch=master \
+    --branch=e2e-branch \
     --rev=HEAD \
     --root="$ROOT" \
     --link="link" \
@@ -324,7 +325,7 @@ BRANCH="$TESTCASE"--BRANCH
 git -C "$REPO" checkout -q -b "$BRANCH"
 echo "$TESTCASE 1" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 1"
-git -C "$REPO" checkout -q master
+git -C "$REPO" checkout -q e2e-branch
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
@@ -340,7 +341,7 @@ assert_file_eq "$ROOT"/link/file "$TESTCASE 1"
 git -C "$REPO" checkout -q "$BRANCH"
 echo "$TESTCASE 2" > "$REPO"/file
 git -C "$REPO" commit -qam "$TESTCASE 2"
-git -C "$REPO" checkout -q master
+git -C "$REPO" checkout -q e2e-branch
 sleep 3
 assert_link_exists "$ROOT"/link
 assert_file_exists "$ROOT"/link/file
@@ -348,7 +349,7 @@ assert_file_eq "$ROOT"/link/file "$TESTCASE 2"
 # Move the branch backward
 git -C "$REPO" checkout -q "$BRANCH"
 git -C "$REPO" reset -q --hard HEAD^
-git -C "$REPO" checkout -q master
+git -C "$REPO" checkout -q e2e-branch
 sleep 3
 assert_link_exists "$ROOT"/link
 assert_file_exists "$ROOT"/link/file
@@ -368,6 +369,7 @@ git -C "$REPO" tag -f "$TAG" >/dev/null
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --rev="$TAG" \
     --root="$ROOT" \
     --link="link" \
@@ -413,6 +415,7 @@ git -C "$REPO" tag -af "$TAG" -m "$TESTCASE 1" >/dev/null
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --rev="$TAG" \
     --root="$ROOT" \
     --link="link" \
@@ -457,6 +460,7 @@ REV=$(git -C "$REPO" rev-list -n1 HEAD)
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --rev="$REV" \
     --root="$ROOT" \
     --link="link" \
@@ -492,6 +496,7 @@ REV=$(git -C "$REPO" rev-list -n1 HEAD)
 GIT_SYNC \
     --one-time \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --rev="$REV" \
     --root="$ROOT" \
     --link="link" \
@@ -512,6 +517,7 @@ git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
     --one-time \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --link="link" \
     > "$DIR"/log."$TESTCASE" 2>&1
@@ -524,6 +530,7 @@ rm -f "$ROOT"/link
 GIT_SYNC \
     --one-time \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --link="link" \
     > "$DIR"/log."$TESTCASE" 2>&1
@@ -545,6 +552,7 @@ GIT_SYNC \
     --one-time \
     --sync-timeout=1s \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --link="link" \
     > "$DIR"/log."$TESTCASE" 2>&1 || true
@@ -556,6 +564,7 @@ GIT_SYNC \
     --period=100ms \
     --sync-timeout=16s \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --link="link" \
     > "$DIR"/log."$TESTCASE" 2>&1 &
@@ -584,6 +593,7 @@ git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --depth="$expected_depth" \
     --root="$ROOT" \
     --link="link" \
@@ -633,7 +643,7 @@ GIT_SYNC \
     --password="wrong" \
     --one-time \
     --repo="file://$REPO" \
-    --branch=master \
+    --branch=e2e-branch \
     --rev=HEAD \
     --root="$ROOT" \
     --link="link" \
@@ -647,7 +657,7 @@ GIT_SYNC \
     --password="my-password" \
     --one-time \
     --repo="file://$REPO" \
-    --branch=master \
+    --branch=e2e-branch \
     --rev=HEAD \
     --root="$ROOT" \
     --link="link" \
@@ -674,7 +684,7 @@ GIT_SYNC \
     --askpass-url="http://$IP/git_askpass" \
     --one-time \
     --repo="file://$REPO" \
-    --branch=master \
+    --branch=e2e-branch \
     --rev=HEAD \
     --root="$ROOT" \
     --link="link" \
@@ -693,7 +703,7 @@ GIT_SYNC \
     --askpass-url="http://$IP/git_askpass" \
     --one-time \
     --repo="file://$REPO" \
-    --branch=master \
+    --branch=e2e-branch \
     --rev=HEAD \
     --root="$ROOT" \
     --link="link" \
@@ -715,6 +725,7 @@ git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --link="link" \
     --sync-hook-command="$SYNC_HOOK_COMMAND" \
@@ -754,6 +765,7 @@ git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --webhook-url="http://$IP" \
     --webhook-success-status=200 \
@@ -796,6 +808,7 @@ git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --webhook-url="http://$IP" \
     --webhook-success-status=200 \
@@ -842,6 +855,7 @@ git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --webhook-url="http://$IP" \
     --webhook-success-status=-1 \
@@ -869,6 +883,7 @@ GIT_SYNC \
     --git="$SLOW_GIT" \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --http-bind=":$BINDPORT" \
     --http-metrics \
@@ -909,7 +924,7 @@ SUBMODULE_REPO_NAME="sub"
 SUBMODULE="$DIR/$SUBMODULE_REPO_NAME"
 mkdir "$SUBMODULE"
 
-git -C "$SUBMODULE" init -q -b master
+git -C "$SUBMODULE" init -q -b e2e-branch
 echo "submodule" > "$SUBMODULE"/submodule
 git -C "$SUBMODULE" add submodule
 git -C "$SUBMODULE" commit -aqm "init submodule file"
@@ -919,7 +934,7 @@ NESTED_SUBMODULE_REPO_NAME="nested-sub"
 NESTED_SUBMODULE="$DIR/$NESTED_SUBMODULE_REPO_NAME"
 mkdir "$NESTED_SUBMODULE"
 
-git -C "$NESTED_SUBMODULE" init -q -b master
+git -C "$NESTED_SUBMODULE" init -q -b e2e-branch
 echo "nested-submodule" > "$NESTED_SUBMODULE"/nested-submodule
 git -C "$NESTED_SUBMODULE" add nested-submodule
 git -C "$NESTED_SUBMODULE" commit -aqm "init nested-submodule file"
@@ -930,6 +945,7 @@ git -C "$REPO" commit -aqm "add submodule"
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --link="link" \
     > "$DIR"/log."$TESTCASE" 2>&1 &
@@ -1004,7 +1020,7 @@ SUBMODULE_REPO_NAME="sub"
 SUBMODULE="$DIR/$SUBMODULE_REPO_NAME"
 mkdir "$SUBMODULE"
 
-git -C "$SUBMODULE" init -q -b master
+git -C "$SUBMODULE" init -q -b e2e-branch
 
 # First sync
 expected_depth="1"
@@ -1017,6 +1033,7 @@ git -C "$REPO" commit -qam "$TESTCASE 1"
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --depth="$expected_depth" \
     --root="$ROOT" \
     --link="link" \
@@ -1080,7 +1097,7 @@ SUBMODULE_REPO_NAME="sub"
 SUBMODULE="$DIR/$SUBMODULE_REPO_NAME"
 mkdir "$SUBMODULE"
 
-git -C "$SUBMODULE" init -q -b master
+git -C "$SUBMODULE" init -q -b e2e-branch
 echo "submodule" > "$SUBMODULE"/submodule
 git -C "$SUBMODULE" add submodule
 git -C "$SUBMODULE" commit -aqm "init submodule file"
@@ -1092,6 +1109,7 @@ git -C "$REPO" commit -aqm "add submodule"
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --link="link" \
     --submodules=off \
@@ -1111,7 +1129,7 @@ SUBMODULE_REPO_NAME="sub"
 SUBMODULE="$DIR/$SUBMODULE_REPO_NAME"
 mkdir "$SUBMODULE"
 
-git -C "$SUBMODULE" init -q -b master
+git -C "$SUBMODULE" init -q -b e2e-branch
 echo "submodule" > "$SUBMODULE"/submodule
 git -C "$SUBMODULE" add submodule
 git -C "$SUBMODULE" commit -aqm "init submodule file"
@@ -1120,7 +1138,7 @@ NESTED_SUBMODULE_REPO_NAME="nested-sub"
 NESTED_SUBMODULE="$DIR/$NESTED_SUBMODULE_REPO_NAME"
 mkdir "$NESTED_SUBMODULE"
 
-git -C "$NESTED_SUBMODULE" init -q -b master
+git -C "$NESTED_SUBMODULE" init -q -b e2e-branch
 echo "nested-submodule" > "$NESTED_SUBMODULE"/nested-submodule
 git -C "$NESTED_SUBMODULE" add nested-submodule
 git -C "$NESTED_SUBMODULE" commit -aqm "init nested-submodule file"
@@ -1134,6 +1152,7 @@ git -C "$REPO" commit -aqm "add submodule"
 GIT_SYNC \
     --period=100ms \
     --repo="file://$REPO" \
+    --branch=e2e-branch \
     --root="$ROOT" \
     --link="link" \
     --submodules=shallow \
@@ -1162,7 +1181,7 @@ git -C "$REPO" commit -qam "$TESTCASE"
 GIT_SYNC \
     --one-time \
     --repo="test@$IP:/src" \
-    --branch=master \
+    --branch=e2e-branch \
     --rev=HEAD \
     --root="$ROOT" \
     --link="link" \


### PR DESCRIPTION
Reliably cleaning up leftover things like `nc` processes is surprisingly
difficult in pure shell.  e2e passes on the master branch now.