### PR TITLE
Fix exit non-zero exit codes when running as pid1

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -269,12 +269,9 @@ func main() {
 	// In case we come up as pid 1, act as init.
 	if os.Getpid() == 1 {
 		fmt.Fprintf(os.Stderr, "INFO: detected pid 1, running init handler\n")
-		err := pid1.ReRun()
+		code, err := pid1.ReRun()
 		if err == nil {
-			os.Exit(0)
-		}
-		if exerr, ok := err.(*exec.ExitError); ok {
-			os.Exit(exerr.ExitCode())
+			os.Exit(code)
 		}
 		fmt.Fprintf(os.Stderr, "ERROR: unhandled pid1 error: %v\n", err)
 		os.Exit(127)

--- a/pkg/pid1/test/fast-exit/main.go
+++ b/pkg/pid1/test/fast-exit/main.go
@@ -4,7 +4,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 
 	"k8s.io/git-sync/pkg/pid1"
 )
@@ -13,12 +12,9 @@ func main() {
 	// In case we come up as pid 1, act as init.
 	if os.Getpid() == 1 {
 		fmt.Printf("detected pid 1, running as init\n")
-		err := pid1.ReRun()
+		code, err := pid1.ReRun()
 		if err == nil {
-			os.Exit(0)
-		}
-		if exerr, ok := err.(*exec.ExitError); ok {
-			os.Exit(exerr.ExitCode())
+			os.Exit(code)
 		}
 		fmt.Printf("unhandled pid1 error: %v\n", err)
 		os.Exit(127)

--- a/pkg/pid1/test/fast-exit/test.sh
+++ b/pkg/pid1/test/fast-exit/test.sh
@@ -3,6 +3,14 @@
 go build
 docker build -t example.com/fast-exit .
 
+# This should exit(42)
+docker run -ti --rm example.com/fast-exit
+RET=$?
+if [ "$RET" != 42 ]; then
+    echo "FAIL: exit code was not preserved: $RET"
+    exit 1
+fi
+
 # In the past we have observed hangs and missed signals.  This *should* run
 # forever.
 while true; do

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -255,6 +255,33 @@ assert_file_eq "$ROOT"/link/file "$TESTCASE"
 pass
 
 ##############################################
+# Test non-zero exit
+##############################################
+testcase "non-zero-exit"
+echo "$TESTCASE" > "$REPO"/file
+git -C "$REPO" commit -qam "$TESTCASE"
+ln -s "$ROOT" "$DIR/rootlink" # symlink to test
+(
+  set +o errexit
+  GIT_SYNC \
+      --one-time \
+      --repo="file://$REPO" \
+      --branch=e2e-branch \
+      --rev=does-not-exit \
+      --root="$DIR/rootlink" \
+      --link="link" \
+      > "$DIR"/log."$TESTCASE" 2>&1
+  RET=$?
+  if [[ "$RET" != 1 ]]; then
+      fail "expected exit code 1, got $RET"
+  fi
+  assert_file_absent "$ROOT"/link
+  assert_file_absent "$ROOT"/link/file
+)
+# Wrap up
+pass
+
+##############################################
 # Test default syncing (master)
 ##############################################
 testcase "default-sync-master"


### PR DESCRIPTION
(v4 branch)

Prior to this we would swallow the exit code and always exit(0).