### PR TITLE
Change the symlink targets to just the SHA

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -46,14 +46,16 @@
 
 FROM {ARG_FROM}
 
-RUN apt-get update \
-    && apt-get -y upgrade \
-    && apt-get -y install \
+RUN echo "deb http://deb.debian.org/debian/ buster-backports main contrib" > \
+        /etc/apt/sources.list.d/backports.list \
+    && apt update \
+    && apt -y upgrade \
+    && apt -y install \
         ca-certificates \
         coreutils \
         socat \
-        git \
         openssh-client \
+    && apt -y -t buster-backports install git \
     && rm -rf /var/lib/apt/lists/*
 
 # By default we will run as this user...

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -602,7 +602,7 @@ func addWorktreeAndSwap(ctx context.Context, gitRoot, dest, branch, rev string, 
 	}
 
 	// Make a worktree for this exact git hash.
-	worktreePath := filepath.Join(gitRoot, "rev-"+hash)
+	worktreePath := filepath.Join(gitRoot, hash)
 	_, err := runCommand(ctx, gitRoot, *flGitCmd, "worktree", "add", worktreePath, "origin/"+branch)
 	log.V(0).Info("adding worktree", "path", worktreePath, "branch", fmt.Sprintf("origin/%s", branch))
 	if err != nil {


### PR DESCRIPTION
This allows users to call readlink() on the link and learn the current
checked out SHA.

Fixes #345 

Depends on #346