### PR TITLE
Change the symlink targets to just the SHA (v4)

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -46,14 +46,16 @@
 
 FROM {ARG_FROM}
 
-RUN apt-get update \
-    && apt-get -y upgrade \
-    && apt-get -y install \
+RUN echo "deb http://deb.debian.org/debian/ buster-backports main contrib" > \
+        /etc/apt/sources.list.d/backports.list \
+    && apt update \
+    && apt -y upgrade \
+    && apt -y install \
         ca-certificates \
         coreutils \
         socat \
-        git \
         openssh-client \
+    && apt -y -t buster-backports install git \
     && rm -rf /var/lib/apt/lists/*
 
 # Add the default UID to /etc/passwd so SSH is satisfied.

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -704,7 +704,7 @@ func (git *repoSync) AddWorktreeAndSwap(ctx context.Context, hash string) error 
 	}
 
 	// Make a worktree for this exact git hash.
-	worktreePath := filepath.Join(git.root, "rev-"+hash)
+	worktreePath := filepath.Join(git.root, hash)
 	_, err := runCommand(ctx, git.root, git.cmd, "worktree", "add", worktreePath, "origin/"+git.branch)
 	log.V(0).Info("adding worktree", "path", worktreePath, "branch", fmt.Sprintf("origin/%s", git.branch))
 	if err != nil {
@@ -1167,7 +1167,9 @@ OPTIONS
     --link <string>, $GIT_SYNC_LINK
             The name of the final symlink (under --root) which will point to the
             current git worktree. This must be a filename, not a path, and may
-            not start with a period. (default: the leaf dir of --repo)
+            not start with a period. The destination of this link (i.e.
+            readlink()) is the currently checked out SHA. (default: the leaf
+            dir of --repo)
 
     --git <string>, $GIT_SYNC_GIT
             The git command to run (subject to PATH search, mostly for testing).

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -33,6 +33,13 @@ function assert_link_exists() {
     fi
 }
 
+function assert_link_eq() {
+    if [[ $(readlink "$1") == "$2" ]]; then
+        return
+    fi
+    fail "link $1 does not point to '$2': $(readlink $1)"
+}
+
 function assert_file_exists() {
     if ! [[ -f "$1" ]]; then
         fail "$1 does not exist"
@@ -313,6 +320,38 @@ sleep 3
 assert_link_exists "$ROOT"/link
 assert_file_exists "$ROOT"/link/file
 assert_file_eq "$ROOT"/link/file "$TESTCASE 1"
+# Wrap up
+pass
+
+##############################################
+# Test readlink
+##############################################
+testcase "readlink"
+# First sync
+echo "$TESTCASE 1" > "$REPO"/file
+git -C "$REPO" commit -qam "$TESTCASE 1"
+GIT_SYNC \
+    --period=100ms \
+    --repo="file://$REPO" \
+    --branch=e2e-branch \
+    --rev=HEAD \
+    --root="$ROOT" \
+    --link="link" \
+    > "$DIR"/log."$TESTCASE" 2>&1 &
+sleep 3
+assert_link_exists "$ROOT"/link
+assert_link_eq "$ROOT"/link $(git -C "$REPO" rev-parse HEAD)
+# Move HEAD forward
+echo "$TESTCASE 2" > "$REPO"/file
+git -C "$REPO" commit -qam "$TESTCASE 2"
+sleep 3
+assert_link_exists "$ROOT"/link
+assert_link_eq "$ROOT"/link $(git -C "$REPO" rev-parse HEAD)
+# Move HEAD backward
+git -C "$REPO" reset -q --hard HEAD^
+sleep 3
+assert_link_exists "$ROOT"/link
+assert_link_eq "$ROOT"/link $(git -C "$REPO" rev-parse HEAD)
 # Wrap up
 pass
 


### PR DESCRIPTION
This allows users to call readlink() on the link and learn the current
checked out SHA.

Fixes #345 

Depends on #346