### PR TITLE
Don't require a TTY to build/test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ $(OUTBIN): .go/$(OUTBIN).stamp
 .go/$(OUTBIN).stamp: $(BUILD_DIRS)
 	@echo "making $(OUTBIN)"
 	@docker run                                                                  \
-	    -ti                                                                      \
+	    -i                                                                       \
 	    --rm                                                                     \
 	    -u $$(id -u):$$(id -g)                                                   \
 	    -v $$(pwd):/src                                                          \
@@ -165,7 +165,7 @@ version:
 
 test: $(BUILD_DIRS)
 	@docker run                                                                  \
-	    -ti                                                                      \
+	    -i                                                                       \
 	    -u $$(id -u):$$(id -g)                                                   \
 	    -v $$(pwd):/src                                                          \
 	    -w /src                                                                  \


### PR DESCRIPTION
Fixes #359