### PR TITLE
Add support for sparse-checkout (v4 vbranch)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ BASEIMAGE ?= k8s.gcr.io/build-image/debian-base:buster-v1.6.0
 IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)__$(OS)_$(ARCH)
 
-BUILD_IMAGE ?= golang:1.15-alpine
+BUILD_IMAGE ?= golang:1.16-alpine
 
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-container' rule.

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -1389,3 +1389,35 @@ assert_file_eq "$ROOT"/link/file "$TESTCASE"
 assert_file_absent "$ROOT"/error.json
 # Wrap up
 pass
+
+##############################################
+# Test sparse-checkout files
+##############################################
+testcase "sparse-checkout"
+echo "!/*" > "$DIR"/sparseconfig
+echo "!/*/" >> "$DIR"/sparseconfig
+echo "file2" >> "$DIR"/sparseconfig
+echo "$TESTCASE" > "$REPO"/file
+echo "$TESTCASE" > "$REPO"/file2
+mkdir "$REPO"/dir
+echo "$TESTCASE" > "$REPO"/dir/file3
+git -C "$REPO" add file2
+git -C "$REPO" add dir
+git -C "$REPO" commit -qam "$TESTCASE"
+GIT_SYNC \
+    --one-time \
+    --repo="file://$REPO" \
+    --branch=e2e-branch \
+    --rev=HEAD \
+    --root="$ROOT" \
+    --link="link" \
+    --sparse-checkout-file="$DIR/sparseconfig" \
+    > "$DIR"/log."$TESTCASE" 2>&1
+assert_link_exists "$ROOT"/link
+assert_file_exists "$ROOT"/link/file2
+assert_file_absent "$ROOT"/link/file
+assert_file_absent "$ROOT"/link/dir/file3
+assert_file_absent "$ROOT"/link/dir
+assert_file_eq "$ROOT"/link/file2 "$TESTCASE"
+# Wrap up
+pass


### PR DESCRIPTION
Port #372 to v4 dev branch (@SpencerMalone)

Wanted to finally tackle https://github.com/kubernetes/git-sync/issues/54, I sidestepped the problem of how to handle the volume of flags that might be required by instead specifying a sparsecheckout file.

The workflow as I've had has been...
- Do a local sparse checkout, add the files you want ignored (or included on if you did a cone pattern https://git-scm.com/docs/git-sparse-checkout#_cone_pattern_set)
- Grab your .git/info/sparecheckout file, and reserve it for later use with this new flag

It's not quite as easy as specifying it all from a CLI, but I think it's a reasonable first pass.

Here are some logs of it being run on https://github.com/SpencerMalone/logstash-output-prometheus:

```
test-repo % cat sparseconfig
!/*
!/*/
README.md
test-repo % docker run --rm -d \
    -v $(pwd)/git-data:/tmp/git \
    -v $(pwd):/test \
    docker.io/registry/git-sync:tag__linux_amd64  \
        --repo=https://github.com/SpencerMalone/logstash-output-prometheus.git \
        --branch=master \
        --sparse-checkout-file=/test/sparseconfig
41494548dd64caf0ff8f7b75e4d3a86014cfaefc40ff31b14ba19accf99aa82f
test-repo % ls git-data/db86200b1ab158ce9ad403d06de2301b15333601
README.md
```

As you can see, I ignored everything but the `README.md`, and sure enough only got that file in my final checkout.