### PR TITLE
Create the root directory if it doesn't exist

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -211,6 +211,13 @@ func (l *customLogger) exportError(content string) {
 
 // writeContent writes the error content to the error file.
 func (l *customLogger) writeContent(content []byte) {
+	if _, err := os.Stat(*flRoot); os.IsNotExist(err) {
+		fileMode := os.FileMode(0755)
+		if err := os.Mkdir(*flRoot, fileMode); err != nil {
+			l.Logger.Error(err, "can't create the root directory", "root", *flRoot)
+			return
+		}
+	}
 	tmpFile, err := ioutil.TempFile(*flRoot, "tmp-err-")
 	if err != nil {
 		l.Logger.Error(err, "can't create temporary error-file", "directory", *flRoot, "prefix", "tmp-err-")


### PR DESCRIPTION
The `git clone` command will create the root directory if it doesn't
exist, but if `git clone` fails, the root directory needs to be present
so that we can write the error to a file under the directory.