### PR TITLE
Downgrade libcurl to work around HTTP bug (v4)

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -44,19 +44,22 @@
 #    => either add the git-sync GID or else set --root, mount a volume,
 #       and manage volume permissions to access that volume
 
-FROM {ARG_FROM}
+#############################################################################
+# First we prepare the image that we want, regardless of build layers.
+#############################################################################
+FROM {ARG_FROM} as prep
 
 RUN echo "deb http://deb.debian.org/debian/ buster-backports main contrib" > \
-        /etc/apt/sources.list.d/backports.list \
-    && apt update \
-    && apt -y upgrade \
-    && apt -y install \
+        /etc/apt/sources.list.d/backports.list
+RUN apt update
+RUN apt -y upgrade
+RUN apt -y install \
         ca-certificates \
         coreutils \
         socat \
-        openssh-client \
-    && apt -y -t buster-backports install git \
-    && rm -rf /var/lib/apt/lists/*
+        openssh-client
+RUN apt -y -t buster-backports install git
+RUN rm -rf /var/lib/apt/lists/*
 
 # Add the default UID to /etc/passwd so SSH is satisfied.
 RUN echo "git-sync:x:65533:65533::/tmp:/sbin/nologin" >> /etc/passwd
@@ -74,8 +77,19 @@ RUN echo "git-sync:x:65533:git-sync" >> /etc/group
 # they use our git-sync group.  If the user needs a different group or sets
 # $GIT_SYNC_ROOT or --root, their values will override this, and we assume they
 # are handling permissions themselves.
-ENV GIT_SYNC_ROOT=/git
 RUN mkdir -m 02775 /git && chown 65533:65533 /git
+
+# Add the platform-specific binary.
+COPY bin/{ARG_OS}_{ARG_ARCH}/{ARG_BIN} /{ARG_BIN}
+
+# Add third-party licenses.
+COPY .licenses/ /LICENSES/
+
+#############################################################################
+# Now we make a "clean" final image.
+#############################################################################
+FROM scratch
+COPY --from=prep / /
 
 # Run as non-root by default.  There's simply no reason to run as root.
 USER 65533:65533
@@ -85,10 +99,7 @@ USER 65533:65533
 ENV HOME=/tmp
 WORKDIR /tmp
 
-# Add the platform-specific binary.
-COPY bin/{ARG_OS}_{ARG_ARCH}/{ARG_BIN} /{ARG_BIN}
-
-# Add third-party licenses.
-COPY .licenses/ /LICENSES/
+# Default values for flags.
+ENV GIT_SYNC_ROOT=/tmp/git
 
 ENTRYPOINT ["/{ARG_BIN}"]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -58,8 +58,15 @@ RUN apt-get -y install --no-install-recommends \
         coreutils \
         socat \
         openssh-client
+# We want a newer git than the norm.
 RUN apt-get -y -t buster-backports install --no-install-recommends \
         git
+# libcurl3-gnutls=7.74.0-1.2~bpo10+1 is broken.  We can downgrade for now until
+# the fix reaches upstream.
+# https://github.com/kubernetes/git-sync/issues/395
+RUN apt-get -y install --no-install-recommends --allow-downgrades \
+        libcurl3-gnutls:amd64=7.64.0-4+deb10u2
+RUN apt-get -y autoremove
 RUN rm -rf /var/lib/apt/lists/*
 
 # Add the default UID to /etc/passwd so SSH is satisfied.

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -51,14 +51,14 @@ FROM {ARG_FROM} as prep
 
 RUN echo "deb http://deb.debian.org/debian/ buster-backports main contrib" > \
         /etc/apt/sources.list.d/backports.list
-RUN apt update
-RUN apt -y upgrade
-RUN apt -y install \
+RUN apt-get update
+RUN apt-get -y upgrade
+RUN apt-get -y install \
         ca-certificates \
         coreutils \
         socat \
         openssh-client
-RUN apt -y -t buster-backports install git
+RUN apt-get -y -t buster-backports install git
 RUN rm -rf /var/lib/apt/lists/*
 
 # Add the default UID to /etc/passwd so SSH is satisfied.

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -53,12 +53,13 @@ RUN echo "deb http://deb.debian.org/debian/ buster-backports main contrib" > \
         /etc/apt/sources.list.d/backports.list
 RUN apt-get update
 RUN apt-get -y upgrade
-RUN apt-get -y install \
+RUN apt-get -y install --no-install-recommends \
         ca-certificates \
         coreutils \
         socat \
         openssh-client
-RUN apt-get -y -t buster-backports install git
+RUN apt-get -y -t buster-backports install --no-install-recommends \
+        git
 RUN rm -rf /var/lib/apt/lists/*
 
 # Add the default UID to /etc/passwd so SSH is satisfied.

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ container: .container-$(DOTFILE_IMAGE) container-name
 	    Dockerfile.in > .dockerfile-$(OS)_$(ARCH)
 	@docker buildx build \
 	    --no-cache \
+	    --progress=plain \
 	    --load \
 	    --platform "$(OS)/$(ARCH)" \
 	    --build-arg HTTP_PROXY=$(HTTP_PROXY) \

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -1432,6 +1432,23 @@ assert_file_eq "$ROOT"/link/file2 "$TESTCASE"
 # Wrap up
 pass
 
+##############################################
+# Test github HTTPS
+# TODO: it would be better if we set up a local HTTPS server
+##############################################
+testcase "github-https"
+GIT_SYNC \
+    --one-time \
+    --repo="https://github.com/kubernetes/git-sync" \
+    --branch=e2e-branch \
+    --rev=HEAD \
+    --root="$ROOT" \
+    --dest="link" \
+    > "$DIR"/log."$TESTCASE" 2>&1
+assert_file_exists "$ROOT"/link/LICENSE
+# Wrap up
+pass
+
 # Finally...
 echo
 echo "all tests passed: cleaning up $DIR"


### PR DESCRIPTION
xref https://github.com/kubernetes/git-sync/issues/395

This also cleans up the image build process to result in less layers