### PR TITLE
Cleanup worktree defensively

### DIFF
--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -311,6 +311,41 @@ assert_file_eq "$ROOT"/link/file "$TESTCASE 1"
 pass
 
 ##############################################
+# Test worktree-cleanup
+##############################################
+testcase "worktree-cleanup"
+
+echo "$TESTCASE" > "$REPO"/file
+git -C "$REPO" commit -qam "$TESTCASE"
+GIT_SYNC \
+    --wait=10 \
+    --repo="file://$REPO" \
+    --branch=e2e-branch \
+    --rev=HEAD \
+    --root="$ROOT" \
+    --dest="link" \
+    > "$DIR"/log."$TESTCASE" 2>&1 &
+
+# wait for first sync
+sleep 4
+assert_link_exists "$ROOT"/link
+assert_file_exists "$ROOT"/link/file
+assert_file_eq "$ROOT"/link/file "$TESTCASE"
+
+# second commit
+echo "$TESTCASE-ok" > "$REPO"/file2
+git -C "$REPO" add file2
+git -C "$REPO" commit -qam "$TESTCASE new file"
+REV=$(git -C "$REPO" rev-list -n1 HEAD)
+git -C "$REPO" worktree add -q "$ROOT"/"$REV" -b e2e --no-checkout
+sleep 10
+
+assert_file_exists "$ROOT"/link/file2
+assert_file_eq "$ROOT"/link/file2 "$TESTCASE-ok"
+# Wrap up
+pass
+
+##############################################
 # Test readlink
 ##############################################
 testcase "readlink"


### PR DESCRIPTION
This is to avoid wedge cases where the worktree was created but this function error'd without cleaning the worktree.
Next timearound, the sync loop fails to create the worktree and bails out.

We observed a case where due to #412, the next sync loop failed with this error: 
" Run(git worktree add /repo/root/rev-nnnn origin/develop): exit status 128: { stdout: \"Preparing worktree (detached HEAD nnnn)\\n\", stderr: \"fatal: '/repo/root/rev-nnnn' already exists\\n\" }"

Fixes #411