### PR TITLE
Add option to read password from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,12 @@ OPTIONS
     --password <string>, $GIT_SYNC_PASSWORD
             The password or personal access token (see github docs) to use for
             git authentication (see --username).  NOTE: for security reasons,
-            users should prefer the environment variable for specifying the
-            password.
+            users should prefer using a file for specifying the password (see
+            --password-file).
+
+    --password-file <string>, $GIT_SYNC_PASSWORD_FILE
+            The path to password file which contains password or personal access
+            token (see --password).
 
     --period <duration>, $GIT_SYNC_PERIOD
             How long to wait between sync attempts.  This must be at least


### PR DESCRIPTION
A new flag `--password-file` is added. This allows git-sync to read
password from file and this is considered as safer than reading from
env or flag directly.

Few more checks are added as well:

1. `--password` and `--password-file` can't be specified at the same
time.
1. If `--username` is specified, then one of `--password` or
`--password-file` must be specified.

Fixes #429