### PR TITLE
Update to latest base image debian-base:buster-v1.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ALL_PLATFORMS := linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 
-BASEIMAGE ?= k8s.gcr.io/build-image/debian-base:buster-v1.6.0
+BASEIMAGE ?= k8s.gcr.io/build-image/debian-base:buster-v1.8.0
 
 IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)__$(OS)_$(ARCH)


### PR DESCRIPTION
Use the latest promoted debian base image: https://github.com/kubernetes/k8s.io/pull/2256

Overcomes 2 critical vulnerabilities:
* https://nvd.nist.gov/vuln/detail/CVE-2021-20231
* https://nvd.nist.gov/vuln/detail/CVE-2021-20232

My organisation cares about published and fixed vulnerabilities and we use this tool extensively, thank you for it :)