### PR TITLE
use branch revision during worktree add

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -684,11 +684,6 @@ func addWorktreeAndSwap(ctx context.Context, gitRoot, dest, branch, rev string, 
 		return nil
 	}
 
-	// GC clone
-	if _, err := cmdRunner.Run(ctx, gitRoot, *flGitCmd, "gc", "--prune=all"); err != nil {
-		return err
-	}
-
 	// Make a worktree for this exact git hash.
 	worktreePath := filepath.Join(gitRoot, hash)
 
@@ -702,9 +697,14 @@ func addWorktreeAndSwap(ctx context.Context, gitRoot, dest, branch, rev string, 
 		return err
 	}
 
-	_, err := cmdRunner.Run(ctx, gitRoot, *flGitCmd, "worktree", "add", worktreePath, "origin/"+branch, "--no-checkout")
+	_, err := cmdRunner.Run(ctx, gitRoot, *flGitCmd, "worktree", "add", "--detach", worktreePath, hash, "--no-checkout")
 	log.V(0).Info("adding worktree", "path", worktreePath, "branch", fmt.Sprintf("origin/%s", branch))
 	if err != nil {
+		return err
+	}
+
+	// GC clone
+	if _, err := cmdRunner.Run(ctx, gitRoot, *flGitCmd, "gc", "--prune=all"); err != nil {
 		return err
 	}
 

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -427,6 +427,43 @@ assert_file_eq "$ROOT"/link/file "$TESTCASE 1"
 pass
 
 ##############################################
+# Test switching branch after depth=1 checkout
+##############################################
+testcase "branch-switch"
+# First sync
+echo "$TESTCASE" > "$REPO"/file
+git -C "$REPO" commit -qam "$TESTCASE"
+GIT_SYNC \
+    --one-time \
+    --repo="file://$REPO" \
+    --branch=e2e-branch \
+    --rev=HEAD \
+    --depth=1 \
+    --root="$ROOT" \
+    --dest="link" \
+    > "$DIR"/log."$TESTCASE" 2>&1
+assert_link_exists "$ROOT"/link
+assert_file_exists "$ROOT"/link/file
+assert_file_eq "$ROOT"/link/file "$TESTCASE"
+BRANCH="${TESTCASE}2"
+git -C "$REPO" checkout -q -b $BRANCH
+echo "$TESTCASE 2" > "$REPO"/file
+git -C "$REPO" commit -qam "$TESTCASE 2"
+GIT_SYNC \
+    --one-time \
+    --repo="file://$REPO" \
+    --branch=$BRANCH \
+    --rev=HEAD \
+    --root="$ROOT" \
+    --dest="link" \
+    >> "$DIR"/log."$TESTCASE" 2>&1
+assert_link_exists "$ROOT"/link
+assert_file_exists "$ROOT"/link/file
+assert_file_eq "$ROOT"/link/file "$TESTCASE 2"
+# Wrap up
+pass
+
+##############################################
 # Test tag syncing
 ##############################################
 testcase "tag-sync"


### PR DESCRIPTION
Change the worktree add call to use the revision hash, avoiding invalid reference issue when using branch name

Fixes kubernetes/git-sync#404