### PR TITLE
v4: use repo default branch instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ docker run -d \
     -u$(id -u):$(id -g) \
     registry/git-sync:tag \
         --repo=https://github.com/kubernetes/git-sync \
-        --branch=master \
         --root=/tmp/git/root \
         --period=30s
 
@@ -113,7 +112,7 @@ OPTIONS
             "username=<value>" and "password=<value>".
 
     --branch <string>, $GIT_SYNC_BRANCH
-            The git branch to check out. (default: master)
+            The git branch to check out. (default: <repo's default branch>)
 
     --change-permissions <int>, $GIT_SYNC_PERMISSIONS
             Optionally change permissions on the checked-out files to the
@@ -272,7 +271,7 @@ EXAMPLE USAGE
 
     git-sync \
         --repo=https://github.com/kubernetes/git-sync \
-        --branch=master \
+        --branch=main \
         --rev=HEAD \
         --period=10s \
         --root=/mnt/git

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -348,13 +348,13 @@ function e2e::head_once_root_exists_but_fails_sanity() {
 ## FIXME: test when repo is valid git, and is already correct
 
 ##############################################
-# Test default syncing (master)
+# Test default-branch syncing
 ##############################################
-function e2e::default_sync_master() {
+function e2e::default_branch_sync() {
     # First sync
     echo "$FUNCNAME 1" > "$REPO"/file
     git -C "$REPO" commit -qam "$FUNCNAME 1"
-    git -C "$REPO" checkout -q -b master
+    git -C "$REPO" checkout -q -b weird-name
 
     GIT_SYNC \
         --period=100ms \


### PR DESCRIPTION
This is ONLY on v4 branch - it's a breaking change for v3.

Fixes #444 