### PR TITLE
Avoid writing to /etc/passwd unless needed

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"os/user"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -586,8 +587,8 @@ func handleError(printUsage bool, format string, a ...interface{}) {
 // Put the current UID/GID into /etc/passwd so SSH can look it up.  This
 // assumes that we have the permissions to write to it.
 func addUser() error {
-	// Don't write a duplicate entry; the Dockerfile already adds the default UID/GID.
-	if os.Getuid() == defaultUID && os.Getgid() == defaultGID {
+	// Skip if the UID already exists. The Dockerfile already adds the default UID/GID.
+	if _, err := user.LookupId(strconv.Itoa(os.Getuid())); err == nil {
 		return nil
 	}
 	home := os.Getenv("HOME")

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -164,6 +164,12 @@ const (
 // initTimeout is a timeout for initialization, like git credentials setup.
 const initTimeout = time.Second * 30
 
+// defaultUID is the default user ID as defined in the Dockerfile
+const defaultUID = 65533
+
+// defaultUID is the default group ID as defined in the Dockerfile
+const defaultGID = 65533
+
 const (
 	submodulesRecursive = "recursive"
 	submodulesShallow   = "shallow"
@@ -580,6 +586,10 @@ func handleError(printUsage bool, format string, a ...interface{}) {
 // Put the current UID/GID into /etc/passwd so SSH can look it up.  This
 // assumes that we have the permissions to write to it.
 func addUser() error {
+	// Don't write a duplicate entry; the Dockerfile already adds the default UID/GID.
+	if os.Getuid() == defaultUID && os.Getgid() == defaultGID {
+		return nil
+	}
 	home := os.Getenv("HOME")
 	if home == "" {
 		cwd, err := os.Getwd()

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -165,12 +165,6 @@ const (
 // initTimeout is a timeout for initialization, like git credentials setup.
 const initTimeout = time.Second * 30
 
-// defaultUID is the default user ID as defined in the Dockerfile
-const defaultUID = 65533
-
-// defaultUID is the default group ID as defined in the Dockerfile
-const defaultGID = 65533
-
 const (
 	submodulesRecursive = "recursive"
 	submodulesShallow   = "shallow"


### PR DESCRIPTION
Some users of git-sync such as airflow allow users to set the runAsUser/runAsGroup, and as a result they always have to set GIT_SYNC_ADD_USER to true: https://github.com/airflow-helm/charts/blob/e1d49498426add959350ab8efacead8f96400759/charts/airflow/templates/_helpers/pods.tpl#L198-L226

But if the you don't override the default runAsUser/runAsGroup (65533) but you do have `GIT_SYNC_ADD_USER=true`, git-sync will write a duplicate entry to /etc/passwd.

I don't think duplicate entries are too much of a problem, but I mainly want this feature because falco spams me with alerts if a pod opens a file under /etc/ for writing :) https://github.com/falcosecurity/falco/blob/f035829ca2881b70a4d13e22abb5f8eb828d3a5f/rules/falco_rules.yaml#L1249