### PR TITLE
Expose the ssh diagnostic message

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -1252,9 +1252,9 @@ func (git *repoSync) SetupGitSSH(setupKnownHosts bool, pathToSSHSecret, pathToSS
 		if err != nil {
 			return fmt.Errorf("can't access SSH known_hosts: %w", err)
 		}
-		err = os.Setenv("GIT_SSH_COMMAND", fmt.Sprintf("ssh -q -o UserKnownHostsFile=%s -i %s", pathToSSHKnownHosts, pathToSSHSecret))
+		err = os.Setenv("GIT_SSH_COMMAND", fmt.Sprintf("ssh -o UserKnownHostsFile=%s -i %s", pathToSSHKnownHosts, pathToSSHSecret))
 	} else {
-		err = os.Setenv("GIT_SSH_COMMAND", fmt.Sprintf("ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i %s", pathToSSHSecret))
+		err = os.Setenv("GIT_SSH_COMMAND", fmt.Sprintf("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i %s", pathToSSHSecret))
 	}
 
 	// set env variable GIT_SSH_COMMAND to force git use customized ssh command


### PR DESCRIPTION
When git-sync fails to clone the git project, the ssh diagnostic message
is suppressed. It is sometimes helpful for debugging the cloning issue.
One example of the ssh dianostic message is
```
ssh: Could not resolve hostname ${REPO_HOST}: Name or service not known
```

This commit removes the `-q` flag from the ssh command to expose such
message.