### PR TITLE
Implement previous hash argument for webhooks

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -589,6 +589,7 @@ func main() {
 
 	initialSync := true
 	failCount := 0
+	oldHash := git.rev
 	for {
 		start := time.Now()
 		ctx, cancel := context.WithTimeout(context.Background(), *flSyncTimeout)
@@ -616,11 +617,12 @@ func main() {
 			continue
 		} else if changed {
 			if webhookRunner != nil {
-				webhookRunner.Send(hash)
+				webhookRunner.Send(hash, oldHash)
 			}
 			if exechookRunner != nil {
-				exechookRunner.Send(hash)
+				exechookRunner.Send(hash, oldHash)
 			}
+			oldHash = hash
 
 			updateSyncMetrics(metricKeySuccess, start)
 		} else {

--- a/pkg/hook/exechook.go
+++ b/pkg/hook/exechook.go
@@ -60,7 +60,7 @@ func (h *Exechook) Name() string {
 }
 
 // Do runs exechook.command, implements Hook.Do
-func (h *Exechook) Do(ctx context.Context, hash string) error {
+func (h *Exechook) Do(ctx context.Context, hash string, oldHash string) error {
 	ctx, cancel := context.WithTimeout(ctx, h.timeout)
 	defer cancel()
 

--- a/pkg/hook/exechook_test.go
+++ b/pkg/hook/exechook_test.go
@@ -36,7 +36,7 @@ func TestNotZeroReturnExechookDo(t *testing.T) {
 			time.Second,
 			l,
 		)
-		err := ch.Do(context.Background(), "")
+		err := ch.Do(context.Background(), "", "")
 		if err == nil {
 			t.Fatalf("expected error but got none")
 		}
@@ -54,7 +54,7 @@ func TestZeroReturnExechookDo(t *testing.T) {
 			time.Second,
 			l,
 		)
-		err := ch.Do(context.Background(), "")
+		err := ch.Do(context.Background(), "", "")
 		if err != nil {
 			t.Fatalf("expected nil but got err")
 		}
@@ -72,7 +72,7 @@ func TestTimeoutExechookDo(t *testing.T) {
 			time.Second,
 			l,
 		)
-		err := ch.Do(context.Background(), "")
+		err := ch.Do(context.Background(), "", "")
 		if err == nil {
 			t.Fatalf("expected err but got nil")
 		}

--- a/pkg/hook/hook_test.go
+++ b/pkg/hook/hook_test.go
@@ -30,13 +30,16 @@ func TestHookData(t *testing.T) {
 	t.Run("hook consumes first hash value", func(t *testing.T) {
 		hd := NewHookData()
 
-		hd.send(hash1)
+		hd.send(hash2,hash1)
 
 		<-hd.events()
 
-		hash := hd.get()
-		if hash1 != hash {
-			t.Fatalf("expected hash %s but got %s", hash1, hash)
+		hash, oldHash := hd.get()
+		if hash2 != hash {
+			t.Fatalf("expected hash %s but got %s", hash2, hash)
+		}
+		if hash1 != oldHash {
+			t.Fatalf("expected oldHash %s but got %s", hash1, hash)
 		}
 	})
 
@@ -45,15 +48,18 @@ func TestHookData(t *testing.T) {
 
 		for i := 0; i < 10; i++ {
 			h := fmt.Sprintf("111111111111111111111111111111111111111%d", i)
-			hd.send(h)
+			hd.send(h, "")
 		}
-		hd.send(hash2)
+		hd.send(hash2, hash1)
 
 		<-hd.events()
 
-		hash := hd.get()
+		hash, oldHash := hd.get()
 		if hash2 != hash {
 			t.Fatalf("expected hash %s but got %s", hash2, hash)
+		}
+		if hash1 != oldHash {
+			t.Fatalf("expected oldHash %s but got %s", hash1, hash)
 		}
 	})
 
@@ -61,18 +67,18 @@ func TestHookData(t *testing.T) {
 		hd := NewHookData()
 		events := hd.events()
 
-		hd.send(hash1)
+		hd.send(hash1, "")
 		<-events
 
-		hash := hd.get()
+		hash, _ := hd.get()
 		if hash1 != hash {
 			t.Fatalf("expected hash %s but got %s", hash1, hash)
 		}
 
-		hd.send(hash1)
+		hd.send(hash1, "")
 		<-events
 
-		hash = hd.get()
+		hash, _ = hd.get()
 		if hash1 != hash {
 			t.Fatalf("expected hash %s but got %s", hash1, hash)
 		}

--- a/pkg/hook/webhook.go
+++ b/pkg/hook/webhook.go
@@ -57,18 +57,19 @@ func (w *Webhook) Name() string {
 }
 
 // Do calls webhook.url, implements Hook.Do
-func (w *Webhook) Do(ctx context.Context, hash string) error {
+func (w *Webhook) Do(ctx context.Context, hash string, oldHash string) error {
 	req, err := http.NewRequest(w.method, w.url, nil)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Gitsync-Hash", hash)
+	req.Header.Set("Gitsync-Hash-Previous", oldHash)
 
 	ctx, cancel := context.WithTimeout(ctx, w.timeout)
 	defer cancel()
 	req = req.WithContext(ctx)
 
-	w.logger.V(0).Info("sending webhook", "hash", hash, "url", w.url, "method", w.method, "timeout", w.timeout)
+	w.logger.V(0).Info("sending webhook", "hash", hash, "oldHash", oldHash, "url", w.url, "method", w.method, "timeout", w.timeout)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err

--- a/pkg/hook/webhook_test.go
+++ b/pkg/hook/webhook_test.go
@@ -33,7 +33,7 @@ func TestWebhookDo(t *testing.T) {
 			time.Second,
 			logging.New("", "", 0),
 		)
-		err := wh.Do(context.Background(), "hash")
+		err := wh.Do(context.Background(), "hash", "oldHash")
 		if err == nil {
 			t.Fatalf("expected error for invalid url but got none")
 		}


### PR DESCRIPTION
First time contributor here. Hello! 👋

I am interested in having access to the previous hash in the webhook functionality so that the receiver can be notified from what rev to what rev things just changed instead of simply sending the latest rev hash.

This change adds a new header (`Gitsync-Hash-Previous`) to the webhook's HTTP request call.

This makes it much simpler to comprehend the changes in an update as one can, for example, `git diff --name-only <oldhash> <hash>` to understand what files changed. I feel this is a valuable functionality to expose and simplifies webhook receivers from tracking the old hash themselves if they don't want to.

I thought a bit about the exechook hook and it didn't really seem to do anything with the hash argument so I didn't spend time adding any special behaviour for the old hash value beyond updating the function signature to satisfy the Hook.Do() interface.

---

As for the CNCF _Contributor License Agreement_, I signed it. I also updated the tests as best as I understood them.

Let me know if I missed anything and feel free to correct my style. (I enabled "_Allow edits by maintainers_".)
