### PR TITLE
Set repoReady even when there wasn't a 1st clone (v4 branch)

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -614,17 +614,20 @@ func main() {
 			cancel()
 			time.Sleep(*flPeriod)
 			continue
-		} else if changed {
-			if webhookRunner != nil {
-				webhookRunner.Send(hash)
-			}
-			if exechookRunner != nil {
-				exechookRunner.Send(hash)
-			}
-
-			updateSyncMetrics(metricKeySuccess, start)
 		} else {
-			updateSyncMetrics(metricKeyNoOp, start)
+			// this might have been called before, but also might not have
+			setRepoReady()
+			if changed {
+				if webhookRunner != nil {
+					webhookRunner.Send(hash)
+				}
+				if exechookRunner != nil {
+					exechookRunner.Send(hash)
+				}
+				updateSyncMetrics(metricKeySuccess, start)
+			} else {
+				updateSyncMetrics(metricKeyNoOp, start)
+			}
 		}
 
 		if initialSync {


### PR DESCRIPTION
E.g. if the repo is already present (after a restart).

Fixes #488