### PR TITLE
Add GC controls, e2e regexes (v4 branch)

### DIFF
--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -1978,35 +1978,53 @@ function list_tests() {
 }
 
 # Figure out which, if any, tests to run.
-tests=($(list_tests))
+all_tests=($(list_tests))
+tests_to_run=()
 
 function print_tests() {
     echo "available tests:"
-    for t in "${tests[@]}"; do
+    for t in "${all_tests[@]}"; do
         echo "    $t"
     done
 }
 
-for t; do
+# Validate and accumulate tests to run if args are specified.
+for arg; do
     # Use -? to list known tests.
-    if [[ "${t}" == "-?" ]]; then
+    if [[ "${arg}" == "-?" ]]; then
         print_tests
         exit 0
     fi
-    # Make sure we know this test.
-    if [[ " ${tests[*]} " =~ " ${t} " ]]; then
-        continue
+    if [[ "${arg}" =~ ^- ]]; then
+        echo "ERROR: unknown flag '${arg}'"
+        exit 1
     fi
-    # Not a known test or flag.
-    echo "ERROR: unknown test or flag: '${t}'"
-    echo
-    print_tests
-    exit 1
+    # Make sure each non-flag arg matches at least one test.
+    nmatches=0
+    for t in "${all_tests[@]}"; do
+        if [[ "${t}" =~ ${arg} ]]; then
+            nmatches=$((nmatches+1))
+            # Don't run tests twice, just keep the first match.
+            if [[ " ${tests_to_run[*]} " =~ " ${t} " ]]; then
+                continue
+            fi
+            tests_to_run+=("${t}")
+            continue
+        fi
+    done
+    if [[ ${nmatches} == 0 ]]; then
+        echo "ERROR: no tests match pattern '${arg}'"
+        echo
+        print_tests
+        exit 1
+    fi
+    tests_to_run+=("${matches[@]}")
 done
+set -- "${tests_to_run[@]}"
 
-# If no tests specified, run them all.
+# If no tests were specified, run them all.
 if [[ "$#" == 0 ]]; then
-    set -- "${tests[@]}"
+    set -- "${all_tests[@]}"
 fi
 
 # Build it

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -475,7 +475,7 @@ function e2e::worktree_cleanup() {
         --branch="$MAIN_BRANCH" \
         --rev=HEAD \
         --root="$ROOT" \
-        --dest="link" \
+        --link="link" \
         >> "$1" 2>&1 &
 
     # wait for first sync
@@ -1871,9 +1871,93 @@ function e2e::github_https() {
         --branch=master \
         --rev=HEAD \
         --root="$ROOT" \
-        --dest="link" \
+        --link="link" \
         >> "$1" 2>&1
     assert_file_exists "$ROOT"/link/LICENSE
+}
+
+##############################################
+# Test git-gc=auto
+##############################################
+function e2e::gc_auto() {
+    echo "$FUNCNAME" > "$REPO"/file
+    git -C "$REPO" commit -qam "$FUNCNAME"
+
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --branch="$MAIN_BRANCH" \
+        --rev=HEAD \
+        --root="$ROOT" \
+        --link="link" \
+        --git-gc="auto" \
+        >> "$1" 2>&1
+    assert_link_exists "$ROOT"/link
+    assert_file_exists "$ROOT"/link/file
+    assert_file_eq "$ROOT"/link/file "$FUNCNAME"
+}
+
+##############################################
+# Test git-gc=always
+##############################################
+function e2e::gc_always() {
+    echo "$FUNCNAME" > "$REPO"/file
+    git -C "$REPO" commit -qam "$FUNCNAME"
+
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --branch="$MAIN_BRANCH" \
+        --rev=HEAD \
+        --root="$ROOT" \
+        --link="link" \
+        --git-gc="always" \
+        >> "$1" 2>&1
+    assert_link_exists "$ROOT"/link
+    assert_file_exists "$ROOT"/link/file
+    assert_file_eq "$ROOT"/link/file "$FUNCNAME"
+}
+
+##############################################
+# Test git-gc=aggressive
+##############################################
+function e2e::gc_aggressive() {
+    echo "$FUNCNAME" > "$REPO"/file
+    git -C "$REPO" commit -qam "$FUNCNAME"
+
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --branch="$MAIN_BRANCH" \
+        --rev=HEAD \
+        --root="$ROOT" \
+        --link="link" \
+        --git-gc="aggressive" \
+        >> "$1" 2>&1
+    assert_link_exists "$ROOT"/link
+    assert_file_exists "$ROOT"/link/file
+    assert_file_eq "$ROOT"/link/file "$FUNCNAME"
+}
+
+##############################################
+# Test git-gc=off
+##############################################
+function e2e::gc_off() {
+    echo "$FUNCNAME" > "$REPO"/file
+    git -C "$REPO" commit -qam "$FUNCNAME"
+
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --branch="$MAIN_BRANCH" \
+        --rev=HEAD \
+        --root="$ROOT" \
+        --link="link" \
+        --git-gc="off" \
+        >> "$1" 2>&1
+    assert_link_exists "$ROOT"/link
+    assert_file_exists "$ROOT"/link/file
+    assert_file_eq "$ROOT"/link/file "$FUNCNAME"
 }
 
 #


### PR DESCRIPTION
Fixes #439.

This does not solve the timeout problem, and it does not do ideal repo-packing, but that is bigger and will have to come in v4 only.

Set gc.autoDetach to "false"

Add --git-gc flag to control GC on each sync
Values:

"auto" - run git gc --auto (default, respects git gc.* configs)
"always" - run git gc
"aggressive" - run git gc --aggressive (may require a longer timeout)
"off" - do not run git gc on each sync (good for --one-time use)

Also makes e2e test treat args as regexes.