### PR TITLE
Support repo change between invocations

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -721,7 +721,7 @@ func addWorktreeAndSwap(ctx context.Context, gitRoot, dest, branch, rev string, 
 	if depth != 0 {
 		args = append(args, "--depth", strconv.Itoa(depth))
 	}
-	args = append(args, "origin", branch)
+	args = append(args, *flRepo, branch)
 
 	// Update from the remote.
 	if _, err := cmdRunner.Run(ctx, gitRoot, nil, *flGitCmd, args...); err != nil {
@@ -948,7 +948,7 @@ func localHashForRev(ctx context.Context, rev, gitRoot string) (string, error) {
 
 // remoteHashForRef returns the upstream hash for a given ref.
 func remoteHashForRef(ctx context.Context, ref, gitRoot string) (string, error) {
-	output, err := cmdRunner.Run(ctx, gitRoot, nil, *flGitCmd, "ls-remote", "-q", "origin", ref)
+	output, err := cmdRunner.Run(ctx, gitRoot, nil, *flGitCmd, "ls-remote", "-q", *flRepo, ref)
 	if err != nil {
 		return "", err
 	}

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -412,6 +412,45 @@ function e2e::readlink() {
 }
 
 ##############################################
+# Test repo syncing
+##############################################
+function e2e::repo_sync() {
+    # Prepare first repo
+    echo "$FUNCNAME 1" > "$REPO"/file
+    git -C "$REPO" commit -qam "$FUNCNAME 1"
+
+    # First sync
+    GIT_SYNC \
+        --repo="file://$REPO" \
+        --branch="$MAIN_BRANCH" \
+        --root="$ROOT" \
+        --dest="link" \
+        --one-time \
+        >> "$1" 2>&1
+    assert_link_exists "$ROOT"/link
+    assert_file_exists "$ROOT"/link/file
+    assert_file_eq "$ROOT"/link/file "$FUNCNAME 1"
+
+    # Prepare other repo
+    OTHER_REPO="${REPO}2"
+    cp -r "$REPO" "$OTHER_REPO"
+    echo "$FUNCNAME 2" > "$OTHER_REPO"/file
+    git -C "$OTHER_REPO" commit -qam "$FUNCNAME 2"
+
+    # Now sync the other repo
+    GIT_SYNC \
+        --repo="file://$OTHER_REPO" \
+        --branch="$MAIN_BRANCH" \
+        --root="$ROOT" \
+        --dest="link" \
+        --one-time \
+        >> "$1" 2>&1
+    assert_link_exists "$ROOT"/link
+    assert_file_exists "$ROOT"/link/file
+    assert_file_eq "$ROOT"/link/file "$FUNCNAME 2"
+}
+
+##############################################
 # Test branch syncing
 ##############################################
 function e2e::branch_sync() {

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -110,8 +110,9 @@ function clean_work() {
     mkdir -p "$WORK"
 }
 
-# REPO is the source repo under test.
+# REPO and REPO2 are the source repos under test.
 REPO="$DIR/repo"
+REPO2="${REPO}2"
 MAIN_BRANCH="e2e-branch"
 function init_repo() {
     rm -rf "$REPO"
@@ -120,6 +121,9 @@ function init_repo() {
     touch "$REPO"/file
     git -C "$REPO" add file
     git -C "$REPO" commit -aqm "init file"
+
+    rm -rf "$REPO2"
+    cp -r "$REPO" "$REPO2"
 }
 
 # ROOT is the volume (usually) used as --root.
@@ -156,6 +160,7 @@ function GIT_SYNC() {
         -u $(id -u):$(id -g) \
         -v "$ROOT":"$ROOT":rw \
         -v "$REPO":"$REPO":ro \
+        -v "$REPO2":"$REPO2":ro \
         -v "$WORK":"$WORK":ro \
         -v "$(pwd)/slow_git_clone.sh":"$SLOW_GIT_CLONE":ro \
         -v "$(pwd)/slow_git_fetch.sh":"$SLOW_GIT_FETCH":ro \
@@ -432,14 +437,12 @@ function e2e::repo_sync() {
     assert_file_eq "$ROOT"/link/file "$FUNCNAME 1"
 
     # Prepare other repo
-    OTHER_REPO="${REPO}2"
-    cp -r "$REPO" "$OTHER_REPO"
-    echo "$FUNCNAME 2" > "$OTHER_REPO"/file
-    git -C "$OTHER_REPO" commit -qam "$FUNCNAME 2"
+    echo "$FUNCNAME 2" > "$REPO2"/file
+    git -C "$REPO2" commit -qam "$FUNCNAME 2"
 
     # Now sync the other repo
     GIT_SYNC \
-        --repo="file://$OTHER_REPO" \
+        --repo="file://$REPO2" \
         --branch="$MAIN_BRANCH" \
         --root="$ROOT" \
         --dest="link" \


### PR DESCRIPTION
Following the thick hint offered by @thockin in #497, this PR replaces the hard-coded literal `"origin"` with the `--repo` value.
This way cleanup takes place even if `--repo` value changes between invocations.

Fixes #497 