### PR TITLE
update the base image to fix vulnerabilities (v4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ALL_PLATFORMS := linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 
-BASEIMAGE ?= k8s.gcr.io/build-image/debian-base:buster-v1.8.0
+BASEIMAGE ?= k8s.gcr.io/build-image/debian-base:buster-v1.10.0
 
 IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)__$(OS)_$(ARCH)


### PR DESCRIPTION
It fixes the critical vulnerabilities: CVE-2021-45960

From Liujingfang1

Patch of #502