### PR TITLE
Use logger.WithName() for web/exechook (v4)

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -574,6 +574,7 @@ func main() {
 	// Startup webhooks goroutine
 	var webhookRunner *hook.HookRunner
 	if *flWebhookURL != "" {
+		log := log.WithName("webhook")
 		webhook := hook.NewWebhook(
 			*flWebhookURL,
 			*flWebhookMethod,
@@ -594,6 +595,7 @@ func main() {
 	// Startup exechooks goroutine
 	var exechookRunner *hook.HookRunner
 	if *flExechookCommand != "" {
+		log := log.WithName("exechook")
 		exechook := hook.NewExechook(
 			cmd.NewRunner(log),
 			*flExechookCommand,

--- a/pkg/hook/exechook.go
+++ b/pkg/hook/exechook.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"k8s.io/git-sync/pkg/cmd"
-	"k8s.io/git-sync/pkg/logging"
 )
 
 // Exechook structure, implements Hook
@@ -39,18 +38,18 @@ type Exechook struct {
 	// Timeout for the command
 	timeout time.Duration
 	// Logger
-	logger *logging.Logger
+	log logintf
 }
 
 // NewExechook returns a new Exechook
-func NewExechook(cmdrunner *cmd.Runner, command, gitroot string, args []string, timeout time.Duration, logger *logging.Logger) *Exechook {
+func NewExechook(cmdrunner *cmd.Runner, command, gitroot string, args []string, timeout time.Duration, log logintf) *Exechook {
 	return &Exechook{
 		cmdrunner: cmdrunner,
 		command:   command,
 		gitRoot:   gitroot,
 		args:      args,
 		timeout:   timeout,
-		logger:    logger,
+		log:       log,
 	}
 }
 
@@ -66,7 +65,7 @@ func (h *Exechook) Do(ctx context.Context, hash string) error {
 
 	worktreePath := filepath.Join(h.gitRoot, hash)
 
-	h.logger.V(0).Info("running exechook", "command", h.command, "timeout", h.timeout)
+	h.log.V(0).Info("running exechook", "command", h.command, "timeout", h.timeout)
 	_, err := h.cmdrunner.Run(ctx, worktreePath, []string{envKV("GITSYNC_HASH", hash)}, h.command, h.args...)
 	return err
 }

--- a/pkg/hook/webhook.go
+++ b/pkg/hook/webhook.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"time"
-
-	"k8s.io/git-sync/pkg/logging"
 )
 
 // WebHook structure, implements Hook
@@ -37,17 +35,17 @@ type Webhook struct {
 	// Timeout for the http/s request
 	timeout time.Duration
 	// Logger
-	logger *logging.Logger
+	log logintf
 }
 
 // NewWebhook returns a new WebHook
-func NewWebhook(url, method string, success int, timeout time.Duration, logger *logging.Logger) *Webhook {
+func NewWebhook(url, method string, success int, timeout time.Duration, log logintf) *Webhook {
 	return &Webhook{
 		url:     url,
 		method:  method,
 		success: success,
 		timeout: timeout,
-		logger:  logger,
+		log:     log,
 	}
 }
 
@@ -68,7 +66,7 @@ func (w *Webhook) Do(ctx context.Context, hash string) error {
 	defer cancel()
 	req = req.WithContext(ctx)
 
-	w.logger.V(0).Info("sending webhook", "hash", hash, "url", w.url, "method", w.method, "timeout", w.timeout)
+	w.log.V(0).Info("sending webhook", "hash", hash, "url", w.url, "method", w.method, "timeout", w.timeout)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err


### PR DESCRIPTION
This makes logs easier to comprehend, since hooks are async.

This required an intermediate interface.