### PR TITLE
Pass the whole environment to exechooks (v3 branch)

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -75,6 +75,9 @@ var flMaxSyncFailures = flag.Int("max-sync-failures", envInt("GIT_SYNC_MAX_SYNC_
 	"the number of consecutive failures allowed before aborting (the first sync must succeed, -1 will retry forever after the initial sync)")
 var flChmod = flag.Int("change-permissions", envInt("GIT_SYNC_PERMISSIONS", 0),
 	"the file permissions to apply to the checked-out files (0 will not change permissions at all)")
+var flSparseCheckoutFile = flag.String("sparse-checkout-file", envString("GIT_SYNC_SPARSE_CHECKOUT_FILE", ""),
+	"the path to a sparse-checkout file.")
+
 var flSyncHookCommand = flag.String("sync-hook-command", envString("GIT_SYNC_HOOK_COMMAND", ""),
 	"DEPRECATED: use --exechook-command instead")
 var flExechookCommand = flag.String("exechook-command", envString("GIT_SYNC_EXECHOOK_COMMAND", ""),
@@ -84,8 +87,6 @@ var flExechookTimeout = flag.Duration("exechook-timeout", envDuration("GIT_SYNC_
 	"the timeout for the command")
 var flExechookBackoff = flag.Duration("exechook-backoff", envDuration("GIT_SYNC_EXECHOOK_BACKOFF", time.Second*3),
 	"the time to wait before retrying a failed command")
-var flSparseCheckoutFile = flag.String("sparse-checkout-file", envString("GIT_SYNC_SPARSE_CHECKOUT_FILE", ""),
-	"the path to a sparse-checkout file.")
 
 var flWebhookURL = flag.String("webhook-url", envString("GIT_SYNC_WEBHOOK_URL", ""),
 	"the URL for a webhook notification when syncs complete (default is no webhook)")

--- a/pkg/hook/exechook.go
+++ b/pkg/hook/exechook.go
@@ -19,6 +19,7 @@ package hook
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -66,8 +67,11 @@ func (h *Exechook) Do(ctx context.Context, hash string) error {
 
 	worktreePath := filepath.Join(h.gitRoot, hash)
 
+	env := os.Environ()
+	env = append(env, envKV("GITSYNC_HASH", hash))
+
 	h.logger.V(0).Info("running exechook", "command", h.command, "timeout", h.timeout)
-	_, err := h.cmdrunner.Run(ctx, worktreePath, []string{envKV("GITSYNC_HASH", hash)}, h.command, h.args...)
+	_, err := h.cmdrunner.Run(ctx, worktreePath, env, h.command, h.args...)
 	return err
 }
 

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -146,6 +146,8 @@ EXECHOOK_COMMAND=/test_exechook_command.sh
 EXECHOOK_COMMAND_FAIL=/test_exechook_command_fail.sh
 EXECHOOK_COMMAND_SLEEPY=/test_exechook_command_with_sleep.sh
 EXECHOOK_COMMAND_FAIL_SLEEPY=/test_exechook_command_fail_with_sleep.sh
+EXECHOOK_ENVKEY=ENVKEY
+EXECHOOK_ENVVAL=envval
 RUNLOG="$DIR/runlog.exechook-fail-retry"
 rm -f $RUNLOG
 touch $RUNLOG
@@ -169,6 +171,7 @@ function GIT_SYNC() {
         -v "$(pwd)/test_exechook_command_fail.sh":"$EXECHOOK_COMMAND_FAIL":ro \
         -v "$(pwd)/test_exechook_command_with_sleep.sh":"$EXECHOOK_COMMAND_SLEEPY":ro \
         -v "$(pwd)/test_exechook_command_fail_with_sleep.sh":"$EXECHOOK_COMMAND_FAIL_SLEEPY":ro \
+        --env "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL" \
         -v "$RUNLOG":/var/log/runs \
         -v "$DOT_SSH/id_test":"/etc/git-secret/ssh":ro \
         --env XDG_CONFIG_HOME=$DIR \
@@ -975,6 +978,7 @@ function e2e::exechook_success() {
     assert_file_eq "$ROOT"/link/file "$FUNCNAME 1"
     assert_file_eq "$ROOT"/link/exechook "$FUNCNAME 1"
     assert_file_eq "$ROOT"/link/link-exechook "$FUNCNAME 1"
+    assert_file_eq "$ROOT"/link/exechook-env "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
 
     # Move forward
     echo "$FUNCNAME 2" > "$REPO"/file
@@ -987,6 +991,7 @@ function e2e::exechook_success() {
     assert_file_eq "$ROOT"/link/file "$FUNCNAME 2"
     assert_file_eq "$ROOT"/link/exechook "$FUNCNAME 2"
     assert_file_eq "$ROOT"/link/link-exechook "$FUNCNAME 2"
+    assert_file_eq "$ROOT"/link/exechook-env "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
 }
 
 ##############################################
@@ -1041,6 +1046,7 @@ function e2e::exechook_success_once() {
     assert_file_eq "$ROOT"/link/file "$FUNCNAME 1"
     assert_file_eq "$ROOT"/link/exechook "$FUNCNAME 1"
     assert_file_eq "$ROOT"/link/link-exechook "$FUNCNAME 1"
+    assert_file_eq "$ROOT"/link/exechook-env "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
 }
 
 ##############################################

--- a/test_exechook_command.sh
+++ b/test_exechook_command.sh
@@ -23,3 +23,4 @@ if [ -z "${GITSYNC_HASH}" ]; then
 fi
 cat file > exechook
 cat ../link/file > link-exechook
+echo "ENVKEY=$ENVKEY" > exechook-env

--- a/test_exechook_command_with_sleep.sh
+++ b/test_exechook_command_with_sleep.sh
@@ -20,3 +20,4 @@
 sleep 3
 cat file > exechook
 cat ../link/file > link-exechook
+echo "ENVKEY=$ENVKEY" > exechook-env


### PR DESCRIPTION
Rather than wiping it all when installing GITSYNC_HASH, retain it and add GITSYNC_HASH.

Fixes #508 