### PR TITLE
Pass the whole environment to exechooks (v4 branch)

### DIFF
--- a/pkg/hook/exechook.go
+++ b/pkg/hook/exechook.go
@@ -19,6 +19,7 @@ package hook
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -65,8 +66,11 @@ func (h *Exechook) Do(ctx context.Context, hash string) error {
 
 	worktreePath := filepath.Join(h.gitRoot, hash)
 
+	env := os.Environ()
+	env = append(env, envKV("GITSYNC_HASH", hash))
+
 	h.log.V(0).Info("running exechook", "command", h.command, "timeout", h.timeout)
-	_, err := h.cmdrunner.Run(ctx, worktreePath, []string{envKV("GITSYNC_HASH", hash)}, h.command, h.args...)
+	_, err := h.cmdrunner.Run(ctx, worktreePath, env, h.command, h.args...)
 	return err
 }
 

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -146,6 +146,8 @@ EXECHOOK_COMMAND=/test_exechook_command.sh
 EXECHOOK_COMMAND_FAIL=/test_exechook_command_fail.sh
 EXECHOOK_COMMAND_SLEEPY=/test_exechook_command_with_sleep.sh
 EXECHOOK_COMMAND_FAIL_SLEEPY=/test_exechook_command_fail_with_sleep.sh
+EXECHOOK_ENVKEY=ENVKEY
+EXECHOOK_ENVVAL=envval
 RUNLOG="$DIR/runlog.exechook-fail-retry"
 rm -f $RUNLOG
 touch $RUNLOG
@@ -169,6 +171,7 @@ function GIT_SYNC() {
         -v "$(pwd)/test_exechook_command_fail.sh":"$EXECHOOK_COMMAND_FAIL":ro \
         -v "$(pwd)/test_exechook_command_with_sleep.sh":"$EXECHOOK_COMMAND_SLEEPY":ro \
         -v "$(pwd)/test_exechook_command_fail_with_sleep.sh":"$EXECHOOK_COMMAND_FAIL_SLEEPY":ro \
+        --env "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL" \
         -v "$RUNLOG":/var/log/runs \
         -v "$DOT_SSH/id_test":"/etc/git-secret/ssh":ro \
         --env XDG_CONFIG_HOME=$DIR \
@@ -1114,6 +1117,7 @@ function e2e::exechook_success() {
     assert_file_eq "$ROOT"/link/file "$FUNCNAME 1"
     assert_file_eq "$ROOT"/link/exechook "$FUNCNAME 1"
     assert_file_eq "$ROOT"/link/link-exechook "$FUNCNAME 1"
+    assert_file_eq "$ROOT"/link/exechook-env "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
 
     # Move forward
     echo "$FUNCNAME 2" > "$REPO"/file
@@ -1126,6 +1130,7 @@ function e2e::exechook_success() {
     assert_file_eq "$ROOT"/link/file "$FUNCNAME 2"
     assert_file_eq "$ROOT"/link/exechook "$FUNCNAME 2"
     assert_file_eq "$ROOT"/link/link-exechook "$FUNCNAME 2"
+    assert_file_eq "$ROOT"/link/exechook-env "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
 }
 
 ##############################################
@@ -1182,6 +1187,7 @@ function e2e::exechook_success_once() {
     assert_file_eq "$ROOT"/link/file "$FUNCNAME 1"
     assert_file_eq "$ROOT"/link/exechook "$FUNCNAME 1"
     assert_file_eq "$ROOT"/link/link-exechook "$FUNCNAME 1"
+    assert_file_eq "$ROOT"/link/exechook-env "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
 }
 
 ##############################################

--- a/test_exechook_command.sh
+++ b/test_exechook_command.sh
@@ -23,3 +23,4 @@ if [ -z "${GITSYNC_HASH}" ]; then
 fi
 cat file > exechook
 cat ../link/file > link-exechook
+echo "ENVKEY=$ENVKEY" > exechook-env

--- a/test_exechook_command_with_sleep.sh
+++ b/test_exechook_command_with_sleep.sh
@@ -20,3 +20,4 @@
 sleep 3
 cat file > exechook
 cat ../link/file > link-exechook
+echo "ENVKEY=$ENVKEY" > exechook-env


### PR DESCRIPTION
Rather than wiping it all when installing GITSYNC_HASH, retain it and add GITSYNC_HASH.