### PR TITLE
v4: e2e: Fix ncsvr to wait for input on HTTP

### DIFF
--- a/_test_tools/ncsvr/ncsvr.sh
+++ b/_test_tools/ncsvr/ncsvr.sh
@@ -20,7 +20,11 @@ if [ -z "$1" -o -z "$2" ]; then
     exit 1
 fi
 
+F="/tmp/fifo.$RANDOM"
+
 while true; do
-    sh -c "$2" | nc -l -p "$1" -N -w0 >/dev/null
+    rm -f "$F"
+    mkfifo "$F"
+    cat "$F" | sh -c "$2" 2>&1 | nc -l -p "$1" -N -w1 > "$F"
     date >> /var/log/hits
 done

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -1061,7 +1061,7 @@ function e2e::askpass_url_wrong_password() {
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
         e2e/test/test-ncsvr \
-        80 '
+        80 'read X
             echo "HTTP/1.1 200 OK"
             echo
             echo "username=my-username"
@@ -1094,7 +1094,7 @@ function e2e::askpass_url() {
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
         e2e/test/test-ncsvr \
-        80 '
+        80 'read X
             echo "HTTP/1.1 200 OK"
             echo
             echo "username=my-username"
@@ -1147,7 +1147,7 @@ function e2e::askpass_url_flaky() {
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
         e2e/test/test-ncsvr \
-        80 '
+        80 'read X
             echo "HTTP/1.1 200 OK"
             echo
             if [ -f /tmp/flag ]; then
@@ -1336,7 +1336,9 @@ function e2e::webhook_success() {
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
         e2e/test/test-ncsvr \
-        80 'echo "HTTP/1.1 200 OK"')
+        80 'read X
+            echo "HTTP/1.1 200 OK"
+           ')
     IP=$(docker_ip "$CTR")
     echo "$FUNCNAME 1" > "$REPO"/file
     git -C "$REPO" commit -qam "$FUNCNAME 1"
@@ -1382,7 +1384,9 @@ function e2e::webhook_fail_retry() {
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
         e2e/test/test-ncsvr \
-        80 'echo "HTTP/1.1 500 Internal Server Error"')
+        80 'read X
+            echo "HTTP/1.1 500 Internal Server Error"
+           ')
     IP=$(docker_ip "$CTR")
     echo "$FUNCNAME 1" > "$REPO"/file
     git -C "$REPO" commit -qam "$FUNCNAME 1"
@@ -1411,7 +1415,9 @@ function e2e::webhook_fail_retry() {
         --ip="$IP" \
         -v "$HITLOG":/var/log/hits \
         e2e/test/test-ncsvr \
-        80 'echo "HTTP/1.1 200 OK"')
+        80 'read X
+            echo "HTTP/1.1 200 OK"
+           ')
     sleep 2
     HITS=$(cat "$HITLOG" | wc -l)
     if [[ "$HITS" < 1 ]]; then
@@ -1430,7 +1436,10 @@ function e2e::webhook_success_once() {
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
         e2e/test/test-ncsvr \
-        80 'sleep 3 && echo "HTTP/1.1 200 OK"')
+        80 'read X
+            sleep 3
+            echo "HTTP/1.1 200 OK"
+           ')
     IP=$(docker_ip "$CTR")
     echo "$FUNCNAME 1" > "$REPO"/file
     git -C "$REPO" commit -qam "$FUNCNAME 1"
@@ -1465,7 +1474,10 @@ function e2e::webhook_fail_retry_once() {
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
         e2e/test/test-ncsvr \
-        80 'sleep 3 && echo "HTTP/1.1 500 Internal Server Error"')
+        80 'read X
+            sleep 3
+            echo "HTTP/1.1 500 Internal Server Error"
+           ')
     IP=$(docker_ip "$CTR")
     echo "$FUNCNAME 1" > "$REPO"/file
     git -C "$REPO" commit -qam "$FUNCNAME 1"
@@ -1499,7 +1511,9 @@ function e2e::webhook_fire_and_forget() {
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
         e2e/test/test-ncsvr \
-        80 'echo "HTTP/1.1 404 Not Found"')
+        80 'read X
+            echo "HTTP/1.1 404 Not Found"
+           ')
     IP=$(docker_ip "$CTR")
 
     # First sync


### PR DESCRIPTION
This caused occasional e2e flakes when the server responded before the
client request had been sent.