### PR TITLE
Pass DBG=1 to `make` to build for debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ VERSION ?= $(shell git describe --tags --always --dirty)
 # This version-strategy uses a manual value to set the version string
 #VERSION ?= 1.2.3
 
+# Set this to 1 to build a debugger-friendly binary.
+DBG ?=
+
 # These are passed to docker when building and testing.
 HTTP_PROXY ?=
 HTTPS_PROXY ?=
@@ -129,6 +132,7 @@ $(OUTBIN): .go/$(OUTBIN).stamp
 	        ARCH=$(ARCH)                                       \
 	        OS=$(OS)                                           \
 	        VERSION=$(VERSION)                                 \
+	        BUILD_DEBUG=$(DBG)                                 \
 	        ./build/build.sh                                   \
 	    "
 	if ! cmp -s .go/$(OUTBIN) $(OUTBIN); then  \


### PR DESCRIPTION
```
$ rm -f bin/linux_amd64/git-sync; make; file bin/linux_amd64/git-sync; ls -l bin/linux_amd64/git-sync
making bin/linux_amd64/git-sync
bin/linux_amd64/git-sync: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=8ggzPLzGh-EzWa2Dh7b7/1TXCJ0weTEiz5c5UKYGG/v8JGce_5rjo0TttLtDiE/ahM4IwfEUSCR_9OMT5BH, stripped
-rwxr-xr-x 1 thockin primarygroup 9248768 Aug 13 16:47 bin/linux_amd64/git-sync

$ rm -f bin/linux_amd64/git-sync; make DBG=1; file bin/linux_amd64/git-sync; ls -l bin/linux_amd64/git-sync
making bin/linux_amd64/git-sync
bin/linux_amd64/git-sync: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=a0s8zSFGr_qgRGx9bzAH/HPs8kT1ilha0T44qd_BK/v59mQiZ6XVAgCk3j9pBa/Z4RiOnHeMKvhiDWI8S3W, not stripped
-rwxr-xr-x 1 thockin primarygroup 14362860 Aug 13 16:47 bin/linux_amd64/git-sync
```