### PR TITLE
Log before running command

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -1045,8 +1045,8 @@ func (git *repoSync) AddWorktreeAndSwap(ctx context.Context, hash string) error 
 		return err
 	}
 
-	_, err := git.run.Run(ctx, git.root, nil, git.cmd, "worktree", "add", "--detach", worktreePath, hash, "--no-checkout")
 	git.log.V(0).Info("adding worktree", "path", worktreePath, "hash", hash)
+	_, err := git.run.Run(ctx, git.root, nil, git.cmd, "worktree", "add", "--detach", worktreePath, hash, "--no-checkout")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
log before running the command - this seems like a mistake made in cut-paste.