### PR TITLE
--max-sync-failures -> --max-failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ OPTIONS
     --man
             Print this manual and exit.
 
-    --max-sync-failures <int>, $GIT_SYNC_MAX_SYNC_FAILURES
+    --max-failures <int>, $GIT_SYNC_MAX_FAILURES
             The number of consecutive failures allowed before aborting (the
             first sync must succeed), Setting this to -1 will retry forever
             after the initial sync.  (default: 0)

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -1205,7 +1205,7 @@ function e2e::auth_askpass_url_flaky() {
     GIT_SYNC \
         --git="$ASKPASS_GIT" \
         --askpass-url="http://$IP/git_askpass" \
-        --max-sync-failures=2 \
+        --max-failures=2 \
         --period=100ms \
         --repo="file://$REPO" \
         --branch="$MAIN_BRANCH" \


### PR DESCRIPTION
Deprecate but retain the old flag and env.  This is in v4 only.

Fixes #617 