### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -23,7 +23,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -550,7 +549,7 @@ func main() {
 
 	if *flUsername != "" {
 		if *flPasswordFile != "" {
-			passwordFileBytes, err := ioutil.ReadFile(*flPasswordFile)
+			passwordFileBytes, err := os.ReadFile(*flPasswordFile)
 			if err != nil {
 				log.Error(err, "can't read password file", "file", *flPasswordFile)
 				os.Exit(1)
@@ -941,7 +940,7 @@ func (git *repoSync) SanityCheck(ctx context.Context) bool {
 }
 
 func dirIsEmpty(dir string) (bool, error) {
-	dirents, err := ioutil.ReadDir(dir)
+	dirents, err := os.ReadDir(dir)
 	if err != nil {
 		return false, err
 	}
@@ -949,7 +948,7 @@ func dirIsEmpty(dir string) (bool, error) {
 }
 
 func removeDirContents(dir string, log *logging.Logger) error {
-	dirents, err := ioutil.ReadDir(dir)
+	dirents, err := os.ReadDir(dir)
 	if err != nil {
 		return err
 	}
@@ -1142,7 +1141,7 @@ func (git *repoSync) AddWorktreeAndSwap(ctx context.Context, hash string) error 
 		return err
 	}
 	gitDirRef := []byte(filepath.Join("gitdir: ../.git/worktrees", worktreePathRelative) + "\n")
-	if err = ioutil.WriteFile(filepath.Join(worktreePath, ".git"), gitDirRef, 0644); err != nil {
+	if err = os.WriteFile(filepath.Join(worktreePath, ".git"), gitDirRef, 0644); err != nil {
 		return err
 	}
 
@@ -1612,13 +1611,13 @@ func (git *repoSync) CallAskPassURL(ctx context.Context) error {
 		_ = resp.Body.Close()
 	}()
 	if resp.StatusCode != 200 {
-		errMessage, err := ioutil.ReadAll(resp.Body)
+		errMessage, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("auth URL returned status %d, failed to read body: %w", resp.StatusCode, err)
 		}
 		return fmt.Errorf("auth URL returned status %d, body: %q", resp.StatusCode, string(errMessage))
 	}
-	authData, err := ioutil.ReadAll(resp.Body)
+	authData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("can't read auth response: %w", err)
 	}

--- a/cmd/git-sync/main_test.go
+++ b/cmd/git-sync/main_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -270,10 +269,7 @@ func TestParseGitConfigs(t *testing.T) {
 }
 
 func TestDirIsEmpty(t *testing.T) {
-	root, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to make a temp dir: %v", err)
-	}
+	root := t.TempDir()
 
 	// Brand new should be empty.
 	if empty, err := dirIsEmpty(root); err != nil {
@@ -289,7 +285,7 @@ func TestDirIsEmpty(t *testing.T) {
 	}
 	for _, file := range []string{"a", "b", "c"} {
 		path := filepath.Join(dir, file)
-		if err := ioutil.WriteFile(path, []byte{}, 0755); err != nil {
+		if err := os.WriteFile(path, []byte{}, 0755); err != nil {
 			t.Fatalf("failed to write a file: %v", err)
 		}
 		if empty, err := dirIsEmpty(dir); err != nil {
@@ -306,7 +302,7 @@ func TestDirIsEmpty(t *testing.T) {
 	}
 	for _, file := range []string{".a", ".b", ".c"} {
 		path := filepath.Join(dir, file)
-		if err := ioutil.WriteFile(path, []byte{}, 0755); err != nil {
+		if err := os.WriteFile(path, []byte{}, 0755); err != nil {
 			t.Fatalf("failed to write a file: %v", err)
 		}
 		if empty, err := dirIsEmpty(dir); err != nil {
@@ -340,10 +336,7 @@ func TestDirIsEmpty(t *testing.T) {
 }
 
 func TestRemoveDirContents(t *testing.T) {
-	root, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("failed to make a temp dir: %v", err)
-	}
+	root := t.TempDir()
 
 	// Brand new should be empty.
 	if empty, err := dirIsEmpty(root); err != nil {
@@ -360,7 +353,7 @@ func TestRemoveDirContents(t *testing.T) {
 	// Populate the dir.
 	for _, file := range []string{"f1", "f2", ".f3", ".f4"} {
 		path := filepath.Join(root, file)
-		if err := ioutil.WriteFile(path, []byte{}, 0755); err != nil {
+		if err := os.WriteFile(path, []byte{}, 0755); err != nil {
 			t.Fatalf("failed to write a file: %v", err)
 		}
 	}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -19,7 +19,6 @@ package logging
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -111,7 +110,7 @@ func (l *Logger) writeContent(content []byte) {
 			return
 		}
 	}
-	tmpFile, err := ioutil.TempFile(l.root, "tmp-err-")
+	tmpFile, err := os.CreateTemp(l.root, "tmp-err-")
 	if err != nil {
 		l.Logger.Error(err, "can't create temporary error-file", "directory", l.root, "prefix", "tmp-err-")
 		return


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://pkg.go.dev/io/ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

- `ioutil.Discard` => `io.Discard`
- `ioutil.NopCloser` => `io.NopCloser`
- `ioutil.ReadAll` => `io.ReadAll`
- `ioutil.ReadDir` => `os.ReadDir`
- `ioutil.ReadFile` => `os.ReadFile`
- `ioutil.TempDir` => `os.MkdirTemp`
- `ioutil.TempFile` => `os.CreateTemp`
- `ioutil.WriteFile` => `os.WriteFile`

`ioutil.TempDir` in `main_test.go` can be replaced with `t.TempDir` from the `testing` package. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir