### PR TITLE
V3 e2e: fix git submodules for file://

### DIFF
--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -520,7 +520,7 @@ function e2e::sync_tag() {
     # First sync
     echo "$FUNCNAME 1" > "$REPO"/file
     git -C "$REPO" commit -qam "$FUNCNAME 1"
-    git -C "$REPO" tag -f "$TAG" >/dev/null
+    git -C "$REPO" tag -f "$TAG" -m "$TAG" >/dev/null
 
     GIT_SYNC \
         --wait=0.1 \
@@ -538,7 +538,7 @@ function e2e::sync_tag() {
     # Add something and move the tag forward
     echo "$FUNCNAME 2" > "$REPO"/file
     git -C "$REPO" commit -qam "$FUNCNAME 2"
-    git -C "$REPO" tag -f "$TAG" >/dev/null
+    git -C "$REPO" tag -f "$TAG" -m "$TAG" >/dev/null
     sleep 3
     assert_link_exists "$ROOT"/link
     assert_file_exists "$ROOT"/link/file
@@ -546,7 +546,7 @@ function e2e::sync_tag() {
 
     # Move the tag backward
     git -C "$REPO" reset -q --hard HEAD^
-    git -C "$REPO" tag -f "$TAG" >/dev/null
+    git -C "$REPO" tag -f "$TAG" -m "$TAG" >/dev/null
     sleep 3
     assert_link_exists "$ROOT"/link
     assert_file_exists "$ROOT"/link/file
@@ -1560,7 +1560,7 @@ function e2e::submodule_sync_default() {
     git -C "$NESTED_SUBMODULE" commit -aqm "init nested-submodule file"
 
     # Add submodule
-    git -C "$REPO" submodule add -q file://$SUBMODULE
+    git -C "$REPO" -c protocol.file.allow=always submodule add -q file://$SUBMODULE
     git -C "$REPO" commit -aqm "add submodule"
 
     GIT_SYNC \
@@ -1579,7 +1579,7 @@ function e2e::submodule_sync_default() {
     # Make change in submodule repo
     echo "$FUNCNAME 2" > "$SUBMODULE"/submodule
     git -C "$SUBMODULE" commit -qam "$FUNCNAME 2"
-    git -C "$REPO" submodule update --recursive --remote > /dev/null 2>&1
+    git -C "$REPO" -c protocol.file.allow=always submodule update --recursive --remote > /dev/null 2>&1
     git -C "$REPO" commit -qam "$FUNCNAME 2"
     sleep 3
     assert_link_exists "$ROOT"/link
@@ -1589,7 +1589,7 @@ function e2e::submodule_sync_default() {
 
     # Move backward in submodule repo
     git -C "$SUBMODULE" reset -q --hard HEAD^
-    git -C "$REPO" submodule update --recursive --remote > /dev/null 2>&1
+    git -C "$REPO" -c protocol.file.allow=always submodule update --recursive --remote > /dev/null 2>&1
     git -C "$REPO" commit -qam "$FUNCNAME 3"
     sleep 3
     assert_link_exists "$ROOT"/link
@@ -1598,9 +1598,9 @@ function e2e::submodule_sync_default() {
     assert_file_eq "$ROOT"/link/$SUBMODULE_REPO_NAME/submodule "submodule"
 
     # Add nested submodule to submodule repo
-    git -C "$SUBMODULE" submodule add -q file://$NESTED_SUBMODULE
+    git -C "$SUBMODULE" -c protocol.file.allow=always submodule add -q file://$NESTED_SUBMODULE
     git -C "$SUBMODULE" commit -aqm "add nested submodule"
-    git -C "$REPO" submodule update --recursive --remote > /dev/null 2>&1
+    git -C "$REPO" -c protocol.file.allow=always submodule update --recursive --remote > /dev/null 2>&1
     git -C "$REPO" commit -qam "$FUNCNAME 4"
     sleep 3
     assert_link_exists "$ROOT"/link
@@ -1614,7 +1614,7 @@ function e2e::submodule_sync_default() {
     rm -rf "$SUBMODULE"/.git/modules/$NESTED_SUBMODULE_REPO_NAME
     git -C "$SUBMODULE" rm -qf $NESTED_SUBMODULE_REPO_NAME
     git -C "$SUBMODULE" commit -aqm "delete nested submodule"
-    git -C "$REPO" submodule update --recursive --remote > /dev/null 2>&1
+    git -C "$REPO" -c protocol.file.allow=always submodule update --recursive --remote > /dev/null 2>&1
     git -C "$REPO" commit -qam "$FUNCNAME 5"
     sleep 3
     assert_link_exists "$ROOT"/link
@@ -1651,7 +1651,7 @@ function e2e::submodule_sync_depth() {
     echo "$FUNCNAME 1" > "$SUBMODULE"/submodule
     git -C "$SUBMODULE" add submodule
     git -C "$SUBMODULE" commit -aqm "submodule $FUNCNAME 1"
-    git -C "$REPO" submodule add -q file://$SUBMODULE
+    git -C "$REPO" -c protocol.file.allow=always submodule add -q file://$SUBMODULE
     git -C "$REPO" config -f "$REPO"/.gitmodules submodule.$SUBMODULE_REPO_NAME.shallow true
     git -C "$REPO" commit -qam "$FUNCNAME 1"
 
@@ -1679,7 +1679,7 @@ function e2e::submodule_sync_depth() {
     # Move forward
     echo "$FUNCNAME 2" > "$SUBMODULE"/submodule
     git -C "$SUBMODULE" commit -aqm "submodule $FUNCNAME 2"
-    git -C "$REPO" submodule update --recursive --remote > /dev/null 2>&1
+    git -C "$REPO" -c protocol.file.allow=always submodule update --recursive --remote > /dev/null 2>&1
     git -C "$REPO" commit -qam "$FUNCNAME 2"
     sleep 3
     assert_link_exists "$ROOT"/link
@@ -1696,7 +1696,7 @@ function e2e::submodule_sync_depth() {
 
     # Move backward
     git -C "$SUBMODULE" reset -q --hard HEAD^
-    git -C "$REPO" submodule update --recursive --remote  > /dev/null 2>&1
+    git -C "$REPO" -c protocol.file.allow=always submodule update --recursive --remote  > /dev/null 2>&1
     git -C "$REPO" commit -qam "$FUNCNAME 3"
     sleep 3
     assert_link_exists "$ROOT"/link
@@ -1728,7 +1728,7 @@ function e2e::submodule_sync_off() {
     git -C "$SUBMODULE" commit -aqm "init submodule file"
 
     # Add submodule
-    git -C "$REPO" submodule add -q file://$SUBMODULE
+    git -C "$REPO" -c protocol.file.allow=always submodule add -q file://$SUBMODULE
     git -C "$REPO" commit -aqm "add submodule"
 
     GIT_SYNC \
@@ -1767,11 +1767,11 @@ function e2e::submodule_sync_shallow() {
     echo "nested-submodule" > "$NESTED_SUBMODULE"/nested-submodule
     git -C "$NESTED_SUBMODULE" add nested-submodule
     git -C "$NESTED_SUBMODULE" commit -aqm "init nested-submodule file"
-    git -C "$SUBMODULE" submodule add -q file://$NESTED_SUBMODULE
+    git -C "$SUBMODULE" -c protocol.file.allow=always submodule add -q file://$NESTED_SUBMODULE
     git -C "$SUBMODULE" commit -aqm "add nested submodule"
 
     # Add submodule
-    git -C "$REPO" submodule add -q file://$SUBMODULE
+    git -C "$REPO" -c protocol.file.allow=always submodule add -q file://$SUBMODULE
     git -C "$REPO" commit -aqm "add submodule"
 
     GIT_SYNC \


### PR DESCRIPTION
I guess upstream git intentionally broke this because of a CVE.

Also fix tag tests to pass -m

xref #646