### PR TITLE
Fix bug when using GIT_SYNC_REV, and GIT_SYNC_ONE_TIME

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -1387,11 +1387,16 @@ func (git *repoSync) RemoteHashForRef(ctx context.Context, ref string) (string, 
 }
 
 func (git *repoSync) RevIsRemoteHash(ctx context.Context) (bool, error) {
-	_, err := git.run.Run(ctx, git.root, nil, git.cmd, "branch", "-r", "--contains", git.rev)
+	count, err := git.run.Run(ctx, git.root, nil, git.cmd, "ls-remote", "-q", git.repo,
+		"|", "cut", "-f1", "|", "grep", git.rev, "|", "wc", "-l")
 	if err != nil {
 		return false, err
 	}
-	return true, nil
+	if strings.Trim(count, " ") == "0" {
+		return false, nil
+	} else {
+		return true, nil
+	}
 }
 
 func (git *repoSync) RevIsHash(ctx context.Context) (bool, error) {

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -1513,7 +1513,11 @@ func (git *repoSync) GetRevs(ctx context.Context) (string, string, error) {
 	if isRemoteHash, err := git.RevIsRemoteHash(ctx); err != nil {
 		git.log.Info("Cannot tell if given rev is a remote hash", "rev", git.rev)
 	} else if isRemoteHash {
-		return "", git.rev, nil
+		localHead, err := git.LocalHashForRev(ctx, "HEAD")
+		if err != nil {
+			return "", "", err
+		}
+		return localHead, git.rev, nil
 	}
 	// Ask git what the exact hash is for rev.
 	local, err := git.LocalHashForRev(ctx, git.rev)

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -1387,12 +1387,12 @@ func (git *repoSync) RemoteHashForRef(ctx context.Context, ref string) (string, 
 }
 
 func (git *repoSync) RevIsRemoteHash(ctx context.Context) (bool, error) {
-	count, err := git.run.Run(ctx, git.root, nil, git.cmd, "ls-remote", "-q", git.repo,
-		"|", "cut", "-f1", "|", "grep", git.rev, "|", "wc", "-l")
+	var command = fmt.Sprintf("%s ls-remote -q %s | cut -f1 | grep -m 1 %s", git.cmd, git.repo, git.rev)
+	output, err := git.run.Run(ctx, git.root, nil, "sh", "-c", command)
 	if err != nil {
 		return false, err
 	}
-	if strings.Trim(count, " ") == "0" {
+	if strings.TrimSpace(string(output)) == "" {
 		return false, nil
 	} else {
 		return true, nil

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -854,6 +854,44 @@ function e2e::sync_sha_once() {
 }
 
 ##############################################
+# Test rev-sync multiple times
+##############################################
+function e2e::sync_sha_multiple_times() {
+    # First sync
+    echo "$FUNCNAME 1" > "$REPO"/file
+    git -C "$REPO" commit -qam "$FUNCNAME 1"
+    REV=$(git -C "$REPO" rev-list -n1 HEAD)
+
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --branch="$MAIN_BRANCH" \
+        --rev="$REV" \
+        --root="$ROOT" \
+        --link="link" \
+        >> "$1" 2>&1
+    assert_link_exists "$ROOT"/link
+    assert_file_exists "$ROOT"/link/file
+    assert_file_eq "$ROOT"/link/file "$FUNCNAME 1"
+    # Second sync
+    echo "$FUNCNAME 2" > "$REPO"/file
+    git -C "$REPO" commit -qam "$FUNCNAME 2"
+    REV=$(git -C "$REPO" rev-list -n1 HEAD)
+
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --branch="$MAIN_BRANCH" \
+        --rev="$REV" \
+        --root="$ROOT" \
+        --link="link" \
+        >> "$1" 2>&1
+    assert_link_exists "$ROOT"/link
+    assert_file_exists "$ROOT"/link/file
+    assert_file_eq "$ROOT"/link/file "$FUNCNAME 2"
+}
+
+##############################################
 # Test syncing after a crash
 ##############################################
 function e2e::sync_crash_cleanup_retry() {


### PR DESCRIPTION
- When using git-sync to sync specific commits, git-sync fails after syncing the first time.
- Error occurs when different commit hashes (not tags) are inputed to GIT_SYNC_REV, and GIT_SYNC_ONE_TIME = true is used.
- Using a commit hash in rev config fails since GetRevs function doesn't account for the possibility that git.rev can be a commit hash. 
- I added a simple function to check if the given rev is a hash (and not a tag) that exists in the remote repository, and returns a HEAD hash for local, and a full given commit for remote to ensure that sync does happen. 