### PR TITLE
Add prometheus metrics to webhook calls

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -177,6 +177,12 @@ var (
 		Help: "How many git syncs completed, partitioned by state (success, error, noop)",
 	}, []string{"status"})
 
+
+	webhookCount = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "git_sync_webhook_total",
+		Help: "How many webhook calls completed, partitioned by state (success, error)",
+	}, []string{"status"})
+
 	askpassCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "git_sync_askpass_calls",
 		Help: "How many git askpass calls completed, partitioned by state (success, error)",

--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -177,12 +177,6 @@ var (
 		Help: "How many git syncs completed, partitioned by state (success, error, noop)",
 	}, []string{"status"})
 
-
-	webhookCount = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "git_sync_webhook_total",
-		Help: "How many webhook calls completed, partitioned by state (success, error)",
-	}, []string{"status"})
-
 	askpassCount = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "git_sync_askpass_calls",
 		Help: "How many git askpass calls completed, partitioned by state (success, error)",


### PR DESCRIPTION
To match the hook package. Was going to add URL into the metric labels but I feel like they could be too large? Open to suggestions for additional labels