### PR TITLE
Fix e2e on 3.x

### DIFF
--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -187,8 +187,9 @@ function GIT_SYNC() {
         -v "$RUNLOG":/var/log/runs \
         -v "$DOT_SSH/id_test":"/etc/git-secret/ssh":ro \
         e2e/git-sync:"${E2E_TAG}"__$(go env GOOS)_$(go env GOARCH) \
-            --add-user \
             --v=6 \
+            --add-user \
+            --git-config='protocol.file.allow:always' \
             "$@"
 }
 

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -959,7 +959,7 @@ function e2e::auth_askpass_url_wrong_password() {
     cat /dev/null > "$HITLOG"
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
-        e2e/test/test-ncsvr \
+        e2e/test/ncsvr \
         80 'read X
             echo "HTTP/1.1 200 OK"
             echo
@@ -991,7 +991,7 @@ function e2e::auth_askpass_url_correct_password() {
     cat /dev/null > "$HITLOG"
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
-        e2e/test/test-ncsvr \
+        e2e/test/ncsvr \
         80 'read X
             echo "HTTP/1.1 200 OK"
             echo
@@ -1044,7 +1044,7 @@ function e2e::auth_askpass_url_flaky() {
     cat /dev/null > "$HITLOG"
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
-        e2e/test/test-ncsvr \
+        e2e/test/ncsvr \
         80 'read X
             echo "HTTP/1.1 200 OK"
             echo
@@ -1231,7 +1231,7 @@ function e2e::webhook_success() {
     cat /dev/null > "$HITLOG"
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
-        e2e/test/test-ncsvr \
+        e2e/test/ncsvr \
         80 'read X
             echo "HTTP/1.1 200 OK"
            ')
@@ -1279,7 +1279,7 @@ function e2e::webhook_fail_retry() {
     cat /dev/null > "$HITLOG"
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
-        e2e/test/test-ncsvr \
+        e2e/test/ncsvr \
         80 'read X
             echo "HTTP/1.1 500 Internal Server Error"
            ')
@@ -1310,7 +1310,7 @@ function e2e::webhook_fail_retry() {
     CTR=$(docker_run \
         --ip="$IP" \
         -v "$HITLOG":/var/log/hits \
-        e2e/test/test-ncsvr \
+        e2e/test/ncsvr \
         80 'read X
             echo "HTTP/1.1 200 OK"
            ')
@@ -1331,7 +1331,7 @@ function e2e::webhook_success_once() {
     cat /dev/null > "$HITLOG"
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
-        e2e/test/test-ncsvr \
+        e2e/test/ncsvr \
         80 'read X
             sleep 3
             echo "HTTP/1.1 200 OK"
@@ -1369,7 +1369,7 @@ function e2e::webhook_fail_retry_once() {
     cat /dev/null > "$HITLOG"
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
-        e2e/test/test-ncsvr \
+        e2e/test/ncsvr \
         80 'read X
             sleep 3
             echo "HTTP/1.1 500 Internal Server Error"
@@ -1407,7 +1407,7 @@ function e2e::webhook_fire_and_forget() {
     cat /dev/null > "$HITLOG"
     CTR=$(docker_run \
         -v "$HITLOG":/var/log/hits \
-        e2e/test/test-ncsvr \
+        e2e/test/ncsvr \
         80 'read X
             echo "HTTP/1.1 404 Not Found"
            ')
@@ -1801,7 +1801,7 @@ function e2e::auth_ssh() {
     CTR=$(docker_run \
         -v "$DOT_SSH":/dot_ssh:ro \
         -v "$REPO":/src:ro \
-        e2e/test/test-sshd)
+        e2e/test/sshd)
     IP=$(docker_ip "$CTR")
     git -C "$REPO" commit -qam "$FUNCNAME"
 


### PR DESCRIPTION
Looking to cut a CVE release I found 2 things:

1) git broke itself (disallowing file:// which we need in e2e)
2) through a typo I have been relying on long-ago built image names to pass e2e