### PR TITLE
v3: Fix cases of syncing different SHAs back to back

### DIFF
--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -670,6 +670,57 @@ function e2e::sync_sha_once() {
     assert_file_exists "$ROOT"/link/file
     assert_file_eq "$ROOT"/link/file "$FUNCNAME"
 }
+#
+##############################################
+# Test sha-HEAD-sha syncing
+##############################################
+function e2e::sync_sha_head_sha() {
+    # First sync
+    echo "$FUNCNAME 1" > "$REPO"/file
+    git -C "$REPO" commit -qam "$FUNCNAME 1"
+    REV=$(git -C "$REPO" rev-list -n1 HEAD)
+    echo "$FUNCNAME 2" > "$REPO"/file
+    git -C "$REPO" commit -qam "$FUNCNAME 2"
+
+    # SHA
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --branch="$MAIN_BRANCH" \
+        --rev="$REV" \
+        --root="$ROOT" \
+        --dest="link" \
+        >> "$1" 2>&1
+    assert_link_exists "$ROOT"/link
+    assert_file_exists "$ROOT"/link/file
+    assert_file_eq "$ROOT"/link/file "$FUNCNAME 1"
+
+    # HEAD
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --branch="$MAIN_BRANCH" \
+        --rev="HEAD" \
+        --root="$ROOT" \
+        --dest="link" \
+        >> "$1" 2>&1
+    assert_link_exists "$ROOT"/link
+    assert_file_exists "$ROOT"/link/file
+    assert_file_eq "$ROOT"/link/file "$FUNCNAME 2"
+
+    # SHA
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --branch="$MAIN_BRANCH" \
+        --rev="$REV" \
+        --root="$ROOT" \
+        --dest="link" \
+        >> "$1" 2>&1
+    assert_link_exists "$ROOT"/link
+    assert_file_exists "$ROOT"/link/file
+    assert_file_eq "$ROOT"/link/file "$FUNCNAME 1"
+}
 
 ##############################################
 # Test syncing after a crash


### PR DESCRIPTION
This is a port from v4 branch

Fixes #657 

Prior to this, it would fail if the 2nd SHA wasn't in the local repo. Now it doesn't care what the local SHA for rev is, it only cares what is checked out at HEAD.

Also deref tags on ls-remote

The short story: `ls-remote` for a tag gets us the SHA of the tag, but `rev-parse HEAD` gets us the SHA of the commit to which that tag is attached.  Those are never equal, so we detect "update needed" every loop.

Now we ask `ls-remote` for the rev and the dereferenced rev.  If that rev is a branch, the deref does nothing.  If that rev is a tag it produces both results.  ls-remote does its own sort, so the deref (if found) comes after the non-deref.  This means that, in both cases, the last line is the one we want.