### PR TITLE
v4: Default http-metrics to false

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -139,7 +139,7 @@ var flGitGC = pflag.String("git-gc", envString("GIT_SYNC_GIT_GC", "auto"),
 
 var flHTTPBind = pflag.String("http-bind", envString("GIT_SYNC_HTTP_BIND", ""),
 	"the bind address (including port) for git-sync's HTTP endpoint")
-var flHTTPMetrics = pflag.Bool("http-metrics", envBool("GIT_SYNC_HTTP_METRICS", true),
+var flHTTPMetrics = pflag.Bool("http-metrics", envBool("GIT_SYNC_HTTP_METRICS", false),
 	"enable metrics on git-sync's HTTP endpoint")
 var flHTTPprof = pflag.Bool("http-pprof", envBool("GIT_SYNC_HTTP_PPROF", false),
 	"enable the pprof debug endpoints on git-sync's HTTP endpoint")


### PR DESCRIPTION
After the change to require http-bind, this default doesn't make sense. My local branch had other commits, which hid this error.