### PR TITLE
Replace deprecated k8s registry references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ALL_PLATFORMS := linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 
-BASEIMAGE ?= k8s.gcr.io/build-image/debian-base:bullseye-v1.4.2
+BASEIMAGE ?= registry.k8s.io/build-image/debian-base:bullseye-v1.4.2
 
 IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)__$(OS)_$(ARCH)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -61,7 +61,7 @@ name from above.  For example:
 ```
 
 When that PR is merged, the promoter bot will copy the images from staging to
-the final prod location (e.g. `k8s.gcr.io/git-sync/git-sync:v3.3.2`).
+the final prod location (e.g. `registry.k8s.io/git-sync/git-sync:v3.3.2`).
 
 ## Make a GitHub release
 

--- a/demo/config/deployment.yaml
+++ b/demo/config/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: git-sync
-        image: k8s.gcr.io/git-sync:v3.1.3
+        image: registry.k8s.io/git-sync:v3.1.3
         volumeMounts:
         - name: markdown
           mountPath: /tmp/git
@@ -24,7 +24,7 @@ spec:
         - name: GIT_SYNC_LINK
           value: git-sync
       - name: hugo
-        image: k8s.gcr.io/hugo
+        image: registry.k8s.io/hugo
         volumeMounts:
         - name: markdown
           mountPath: /src

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -35,7 +35,7 @@ spec:
           # "current" (see -dest below) which points to a checked-out copy of
           # the master branch (see -branch) of the repo (see -repo).
           # NOTE: git-sync already runs as non-root.
-          image: k8s.gcr.io/git-sync/git-sync:v4.0.0
+          image: registry.k8s.io/git-sync/git-sync:v4.0.0
           args:
             - --repo=https://github.com/kubernetes/git-sync
             - --branch=master

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -79,7 +79,7 @@ as user ID "65533" which is created for running git-sync as non-root.
       # ...
       containers:
       - name: git-sync
-        image: k8s.gcr.io/git-sync:v3.1.5
+        image: registry.k8s.io/git-sync:v3.1.5
         args:
          - "--ssh"
          - "--repo=git@github.com:foo/bar"
@@ -138,7 +138,7 @@ spec:
           defaultMode: 0400
       containers:
       - name: git-sync
-        image: k8s.gcr.io/git-sync:v3.1.5
+        image: registry.k8s.io/git-sync:v3.1.5
         args:
          - "--ssh"
          - "--repo=git@github.com:torvalds/linux"


### PR DESCRIPTION
Problem: Previously all of Kubernetes' image hosting has been out of gcr.io. There were significant egress costs associated with this when images were pulled from entities outside gcp.  Refer to https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Solution: As highlighted at KubeCon NA 2022 k8s infra SIG update, the replacement for k8s.gcr.io which is registry.k8s.io is now ready for mainstream use and the old k8s.gcr.io has been formally deprecated and projects are requested to migrate off it. This commit migrates remaining references for kubernetes/git-sync to registry.k8s.io.


Umbrella issue: https://github.com/kubernetes/k8s.io/issues/4738