### PR TITLE
V3: prevent git's 'dubious ownership' error

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -1285,6 +1285,10 @@ func setupDefaultGitConfigs(ctx context.Context) error {
 		// How to manage credentials (for those modes that need it).
 		key: "credential.helper",
 		val: "cache --timeout 3600",
+	}, {
+		// Our working root is safe (avoid a "dubious ownership" error).
+		key: "safe.directory",
+		val: "*",
 	}}
 	for _, kv := range configs {
 		if _, err := cmdRunner.Run(ctx, "", nil, *flGitCmd, "config", "--global", kv.key, kv.val); err != nil {

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -99,7 +99,7 @@ func (l *Logger) DeleteErrorFile() {
 // writeContent writes the error content to the error file.
 func (l *Logger) writeContent(content []byte) {
 	if _, err := os.Stat(l.root); os.IsNotExist(err) {
-		fileMode := os.FileMode(0755)
+		fileMode := os.FileMode(0775) // umask applies
 		if err := os.Mkdir(l.root, fileMode); err != nil {
 			l.Logger.Error(err, "can't create the root directory", "root", l.root)
 			return


### PR DESCRIPTION
To prove this, we run the e2e test as a different user.  To do that, we need git-sync to make sure that everything is group accessible.  To clean up after the test, we need everything to be group writable.  To do that, we add a new flag: `--group-write`.


Fixes #696 