### PR TITLE
Run hooks at startup

### DIFF
--- a/_test_tools/exechook_command.sh
+++ b/_test_tools/exechook_command.sh
@@ -23,3 +23,4 @@ if [ -z "${GITSYNC_HASH}" ]; then
 fi
 cat file > exechook
 echo "ENVKEY=$ENVKEY" > exechook-env
+date >> /var/log/runs

--- a/v3-to-v4.md
+++ b/v3-to-v4.md
@@ -133,6 +133,12 @@ git-sync v3 container images defaulted `--root` to "/tmp/git".  In v4, that has
 moved to "/git".  Users who mount a volume and expect to use the default
 `--root` must mount it on "/git".
 
+## Hooks
+
+git-sync v3 could "lose" exechook and webhook calls in the face of the app
+restarting.  In v4, app startup is treated as a sync, even if the correct hash
+was already present, which means that hooks are always called.
+
 ## Other changes
 
 git-sync v3 would allow invalidly formatted env vars (e.g. a value that was


### PR DESCRIPTION
This ensures we do not miss events.  E.g.

before:
    t0: hash changes to X
    t1: send webhook(X), waiting for response
    t2: hash changes to Y
    t3: queue next webhook(Y) but can't send because previous is not done
    t4: crash
    t5: restart
    t6: find repo at hash Y

    no webhook(Y) was sent.

after:
    t0: hash changes to X
    t1: send webhook(X), waiting for response
    t2: hash changes to Y
    t3: queue next webhook(Y) but can't send because previous is not done
    t4: crash
    t5: restart
    t6: find repo at hash Y
    t7: send webhook(Y), waiting for response

Fixes #313
