### PR TITLE
Make container builds faster

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -50,7 +50,7 @@ ARG FORCE_REBUILD=0
 RUN apt-get -y -qq -o Dpkg::Use-Pty=0 update
 RUN apt-get -y -qq -o Dpkg::Use-Pty=0 -y upgrade
 
-RUN apt-get -y -qq -o Dpkg::Use-Pty=0 install bash # for the staging scripts and ldd
+RUN apt-get -y -qq -o Dpkg::Use-Pty=0 install --no-install-recommends bash # for the staging scripts and ldd
 RUN mkdir -p {ARG_STAGING}
 COPY stage_binaries.sh /
 RUN /stage_binaries.sh -o {ARG_STAGING} \

--- a/stage_binaries.sh
+++ b/stage_binaries.sh
@@ -70,6 +70,11 @@ function stage_file() {
     local file="$1"
     local staging="$2"
 
+    # short circuit if we have done this file before
+    if [[ -e "${staging}/${file}" ]]; then
+        return
+    fi
+
     # copy the named path
     cp -a --parents "${file}" "${staging}"
 


### PR DESCRIPTION
Builds for other architectures went from 20m to 6.5m.

e2e Still passes locally.