### PR TITLE
Update to use bookworm base image

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -63,14 +63,14 @@ RUN /stage_binaries.sh -o {ARG_STAGING} \
 	-b /bin/sed
 RUN ln -sf /bin/dash {ARG_STAGING}/bin/sh
 
-COPY clean_distroless.sh /clean_distroless.sh
-RUN /clean_distroless.sh {ARG_STAGING}
-
 # We need to use distroless/base for tzdata, glibc, and some others.
 FROM gcr.io/distroless/base as intermediate
 
 # Docker doesn't do vars in COPY, so we can't use a regular ARG.
 COPY --from=base {ARG_STAGING} /
+
+COPY clean_distroless.sh /clean_distroless.sh
+RUN /clean_distroless.sh
 
 # Add the default UID to /etc/passwd so SSH is satisfied.
 RUN echo "git-sync:x:65533:65533::/tmp:/sbin/nologin" >> /etc/passwd

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ALL_PLATFORMS := linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x
 OS := $(if $(GOOS),$(GOOS),$(shell go env GOOS))
 ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 
-BASEIMAGE ?= registry.k8s.io/build-image/debian-base:bullseye-v1.4.3
+BASEIMAGE ?= registry.k8s.io/build-image/debian-base:bookworm-v1.0.0
 
 IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)

--- a/clean_distroless.sh
+++ b/clean_distroless.sh
@@ -14,24 +14,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# USAGE: clean-distroless.sh <staging_dir>
-
-if [ -z "$1" ]; then
-    echo "usage: $0 <staging-dir>"
-    exit 1
-fi
-ROOT="$1"
-
 # This script needs to be "sh" and not "bash", but there are no arrays in sh,
 # except for "$@".  We need array semantics on the off chance we ever have a
 # pathname with spaces in it.
+#
+# This list is not generic - it is specific to git-sync on debian bookworm.
 set -- \
     /usr/share/base-files \
+    /usr/share/doc \
     /usr/share/man \
     /usr/lib/*-linux-gnu/gconv \
     /usr/bin/c_rehash \
+    /usr/bin/git-shell \
     /usr/bin/openssl \
-    /iptables-wrapper-installer.sh \
+    /usr/bin/scalar \
+    /usr/bin/scp \
+    /usr/bin/sftp \
+    /usr/bin/ssh-add \
+    /usr/bin/ssh-agent \
+    /usr/bin/ssh-keygen \
+    /usr/bin/ssh-keyscan \
+    /usr/lib/git-core/git-shell \
+    /usr/bin/openssl \
+    /usr/lib/git-core/git-daemon \
+    /usr/lib/git-core/git-http-backend \
+    /usr/lib/git-core/git-http-fetch \
+    /usr/lib/git-core/git-http-push \
+    /usr/lib/git-core/git-imap-send \
+    /usr/lib/openssh/ssh-keysign \
+    /usr/lib/openssh/ssh-pkcs11-helper \
+    /usr/lib/openssh/ssh-sk-helper \
+    /usr/share/gitweb \
     /clean-distroless.sh
 
 for item; do

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -169,6 +169,10 @@ function docker_signal() {
 # tags are system-global, but one might have multiple repos checked out.
 E2E_TAG=$(git rev-parse --show-toplevel | sed 's|/|_|g')
 
+# Setting IMAGE forces the test to use a specific image instead of the current
+# tree.
+IMAGE="${IMAGE:-"e2e/git-sync:${E2E_TAG}__$(go env GOOS)_$(go env GOARCH)"}"
+
 # DIR is the directory in which all this test's state lives.
 RUNID="${RANDOM}${RANDOM}"
 DIR="/tmp/git-sync-e2e.$RUNID"
@@ -264,7 +268,7 @@ function GIT_SYNC() {
         --env "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL" \
         -v "$RUNLOG":/var/log/runs \
         -v "$DOT_SSH/id_test":"/etc/git-secret/ssh":ro \
-        e2e/git-sync:"${E2E_TAG}"__$(go env GOOS)_$(go env GOARCH) \
+        "${IMAGE}" \
             -v=6 \
             --add-user \
             --group-write \


### PR DESCRIPTION
This include symlinks from /bin -> /usr/bin (and lib, and ...), which broke the build script.  See comments in there for details.