### PR TITLE
Make relative-path submodules work, via origin

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -45,13 +45,14 @@ func NewRunner(log logintf) Runner {
 	return Runner{log: log}
 }
 
-// Run runs given command
+// Run runs the given command, returning the stdout, stderr, and any error.
 func (r Runner) Run(ctx context.Context, cwd string, env []string, command string, args ...string) (string, string, error) {
 	// call depth = 2 to erase the runWithStdin frame and this one
 	return runWithStdin(ctx, r.log.WithCallDepth(2), cwd, env, "", command, args...)
 }
 
-// RunWithStdin runs given command with standard input
+// RunWithStdin runs the given command with standard input, returning the stdout,
+// stderr, and any error.
 func (r Runner) RunWithStdin(ctx context.Context, cwd string, env []string, stdin, command string, args ...string) (string, string, error) {
 	// call depth = 2 to erase the runWithStdin frame and this one
 	return runWithStdin(ctx, r.log.WithCallDepth(2), cwd, env, stdin, command, args...)
@@ -80,10 +81,10 @@ func runWithStdin(ctx context.Context, log logintf, cwd string, env []string, st
 	stdout := strings.TrimSpace(outbuf.String())
 	stderr := strings.TrimSpace(errbuf.String())
 	if ctx.Err() == context.DeadlineExceeded {
-		return "", "", fmt.Errorf("Run(%s): %w: { stdout: %q, stderr: %q }", cmdStr, ctx.Err(), stdout, stderr)
+		return stdout, stderr, fmt.Errorf("Run(%s): %w: { stdout: %q, stderr: %q }", cmdStr, ctx.Err(), stdout, stderr)
 	}
 	if err != nil {
-		return "", "", fmt.Errorf("Run(%s): %w: { stdout: %q, stderr: %q }", cmdStr, err, stdout, stderr)
+		return stdout, stderr, fmt.Errorf("Run(%s): %w: { stdout: %q, stderr: %q }", cmdStr, err, stdout, stderr)
 	}
 	log.V(6).Info("command result", "stdout", stdout, "stderr", stderr, "time", wallTime)
 


### PR DESCRIPTION
The "origin" remote is implicitly used as the basis for relative-paths in submodules.  It's very subtly documented, and I have no idea if there are other places where it is used.  It seems git really expects it to exist, so let's just do that.

Fixes #763