### PR TITLE
Handle errors from credential refresh (v3)

### DIFF
--- a/cmd/git-sync/main.go
+++ b/cmd/git-sync/main.go
@@ -1083,7 +1083,9 @@ func revIsHash(ctx context.Context, rev, gitRoot string) (bool, error) {
 // syncRepo syncs the branch of a given repository to the destination at the given rev.
 // returns (1) whether a change occured, (2) the new hash, and (3) an error if one happened
 func syncRepo(ctx context.Context, repo, branch, rev string, depth int, gitRoot, dest string, refreshCreds func(context.Context) error, submoduleMode string) (bool, string, error) {
-	refreshCreds(ctx)
+	if err := refreshCreds(ctx); err != nil {
+		return false, "", fmt.Errorf("credential refresh failed: %w", err)
+	}
 
 	currentWorktreeGit := filepath.Join(dest, ".git")
 	var hash string


### PR DESCRIPTION
Previously, errors from askpass and credential storage were being ignored, causing git clone/fetch to later error with hard-to-read errors.

Now the error indicates the credential refresh as the problem, and either does not try to sync (if no creds) or tries to use previous creds (if they were fetched at some point).

Replaces #775