### PR TITLE
Lint fixes (part 1)

### DIFF
--- a/main.go
+++ b/main.go
@@ -1149,7 +1149,7 @@ func setRepoReady() {
 // it is deadlocked.
 func sleepForever() {
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, os.Kill)
+	signal.Notify(c, os.Interrupt)
 	<-c
 	os.Exit(0)
 }
@@ -1932,7 +1932,7 @@ func (git *repoSync) SetupGitSSH(setupKnownHosts bool, pathToSSHSecret, pathToSS
 		}
 		sshCmd += fmt.Sprintf(" -o StrictHostKeyChecking=yes -o UserKnownHostsFile=%s", pathToSSHKnownHosts)
 	} else {
-		sshCmd += fmt.Sprintf(" -o StrictHostKeyChecking=no")
+		sshCmd += " -o StrictHostKeyChecking=no"
 	}
 
 	git.log.V(9).Info("setting GIT_SSH_COMMAND", "value", sshCmd)
@@ -2086,7 +2086,6 @@ func parseGitConfigs(configsFlag string) ([]keyVal, error) {
 			}
 		}
 		close(ch)
-		return
 	}()
 
 	result := []keyVal{}

--- a/main_test.go
+++ b/main_test.go
@@ -747,7 +747,9 @@ func TestTouch(t *testing.T) {
 	stamp := time.Now()
 	time.Sleep(100 * time.Millisecond)
 
-	touch(dirPath)
+	if err := touch(dirPath); err != nil {
+		t.Fatalf("touch(dir) failed: %v", err)
+	}
 	if dirInfo, err := os.Stat(dirPath.String()); err != nil {
 		t.Fatalf("can't stat dir: %v", err)
 	} else if !dirInfo.IsDir() {
@@ -756,7 +758,9 @@ func TestTouch(t *testing.T) {
 		t.Errorf("touch(dir) mtime %v is not after %v", dirInfo.ModTime(), stamp)
 	}
 
-	touch(filePath)
+	if err := touch(filePath); err != nil {
+		t.Fatalf("touch(file) failed: %v", err)
+	}
 	if fileInfo, err := os.Stat(filePath.String()); err != nil {
 		t.Fatalf("can't stat file: %v", err)
 	} else if fileInfo.IsDir() {
@@ -765,7 +769,9 @@ func TestTouch(t *testing.T) {
 		t.Errorf("touch(file) mtime %v is not after %v", fileInfo.ModTime(), stamp)
 	}
 
-	touch(newfilePath)
+	if err := touch(newfilePath); err != nil {
+		t.Fatalf("touch(newfile) failed: %v", err)
+	}
 	if newfileInfo, err := os.Stat(newfilePath.String()); err != nil {
 		t.Fatalf("can't stat newfile: %v", err)
 	} else if newfileInfo.IsDir() {


### PR DESCRIPTION
Fix a few misc linter issues:

main_test.go:750:7: Error return value is not checked (errcheck)
        touch(dirPath)
             ^
main_test.go:759:7: Error return value is not checked (errcheck)
        touch(filePath)
             ^
main_test.go:768:7: Error return value is not checked (errcheck)
        touch(newfilePath)
             ^
main.go:2089:3: S1023: redundant `return` statement (gosimple)
                return
                ^
main.go:1935:13: S1039: unnecessary use of fmt.Sprintf (gosimple)
                sshCmd += fmt.Sprintf(" -o StrictHostKeyChecking=no")
                          ^
main.go:1152:33: SA1016: os.Kill cannot be trapped (did you mean syscall.SIGTERM?) (staticcheck)
        signal.Notify(c, os.Interrupt, os.Kill)
