### PR TITLE
Remove trailing newlines from errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func envBoolOrError(def bool, key string, alts ...string) (bool, error) {
 		if err == nil {
 			return parsed, nil
 		}
-		return false, fmt.Errorf("ERROR: invalid bool env %s=%q: %v\n", key, val, err)
+		return false, fmt.Errorf("ERROR: invalid bool env %s=%q: %w", key, val, err)
 	}
 
 	if val := os.Getenv(key); val != "" {
@@ -154,7 +154,7 @@ func envIntOrError(def int, key string, alts ...string) (int, error) {
 		if err == nil {
 			return int(parsed), nil
 		}
-		return 0, fmt.Errorf("ERROR: invalid int env %s=%q: %v\n", key, val, err)
+		return 0, fmt.Errorf("ERROR: invalid int env %s=%q: %w", key, val, err)
 	}
 
 	if val := os.Getenv(key); val != "" {
@@ -184,7 +184,7 @@ func envFloatOrError(def float64, key string, alts ...string) (float64, error) {
 		if err == nil {
 			return parsed, nil
 		}
-		return 0, fmt.Errorf("ERROR: invalid float env %s=%q: %v\n", key, val, err)
+		return 0, fmt.Errorf("ERROR: invalid float env %s=%q: %w", key, val, err)
 	}
 
 	if val := os.Getenv(key); val != "" {
@@ -214,7 +214,7 @@ func envDurationOrError(def time.Duration, key string, alts ...string) (time.Dur
 		if err == nil {
 			return parsed, nil
 		}
-		return 0, fmt.Errorf("ERROR: invalid duration env %s=%q: %v\n", key, val, err)
+		return 0, fmt.Errorf("ERROR: invalid duration env %s=%q: %w", key, val, err)
 	}
 
 	if val := os.Getenv(key); val != "" {


### PR DESCRIPTION
I believe we print a new line anyway from e.g. envInt, which calls fmt.Fprintln.

Found by staticcheck:

main.go:127:17: error strings should not end with punctuation or newlines (ST1005)
main.go:157:13: error strings should not end with punctuation or newlines (ST1005)
main.go:187:13: error strings should not end with punctuation or newlines (ST1005)
main.go:217:13: error strings should not end with punctuation or newlines (ST1005)
