### PR TITLE
lint: break out of loop, not just out of select statement

### DIFF
--- a/main.go
+++ b/main.go
@@ -2077,10 +2077,11 @@ func parseGitConfigs(configsFlag string) ([]keyVal, error) {
 	ch := make(chan rune)
 	stop := make(chan bool)
 	go func() {
+	loopOverConfigFlags:
 		for _, r := range configsFlag {
 			select {
 			case <-stop:
-				break
+				break loopOverConfigFlags
 			default:
 				ch <- r
 			}


### PR DESCRIPTION
Caught by staticcheck:

main.go:2083:5: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
