### PR TITLE
Enable github actions for CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,48 @@
+---
+name: CI
+
+'on':
+  - push
+  - pull_request
+
+env:
+  GOPROXY: https://proxy.golang.org
+  GOPATH: ${{ github.workspace }}/go
+
+permissions:
+  contents: read
+
+jobs:
+  build-linux-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20.6'
+
+      - uses: actions/checkout@v3
+        with:
+          path: git-sync
+
+      - name: make all-build
+        working-directory: git-sync
+        run: |
+          make all-build
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20.6'
+
+      - uses: actions/checkout@v3
+        with:
+          path: git-sync
+
+      - name: make test
+        working-directory: git-sync
+        run: |
+          make test

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -185,6 +185,17 @@ function clean_work() {
     mkdir -p "$WORK"
 }
 
+# config_repo sets required git config, so we don't depend on (shared) global git config.
+#
+# Args:
+#  $1: directory of git repo
+function config_repo() {
+    local repo=$1
+
+    git -C "$repo" config user.email "git-sync-test@example.com"
+    git -C "$repo" config user.name "git-sync-test"
+}
+
 # REPO and REPO2 are the source repos under test.
 REPO="$DIR/repo"
 REPO2="${REPO}2"
@@ -193,6 +204,7 @@ function init_repo() {
     rm -rf "$REPO"
     mkdir -p "$REPO"
     git -C "$REPO" init -q -b "$MAIN_BRANCH"
+    config_repo "$REPO"
     touch "$REPO/file"
     git -C "$REPO" add file
     git -C "$REPO" commit -aqm "init file"
@@ -374,6 +386,7 @@ function e2e::init_root_is_under_another_repo() {
     mkdir -p "$ROOT/subdir/root"
     date > "$ROOT/subdir/root/file" # so it is not empty
     git -C "$ROOT/subdir" init -q
+    config_repo "$ROOT/subdir"
 
     GIT_SYNC \
         --one-time \
@@ -395,6 +408,7 @@ function e2e::init_root_fails_sanity() {
 
     # Make an invalid git repo.
     git -C "$ROOT" init -q
+    config_repo "$ROOT"
     echo "ref: refs/heads/nonexist" > "$ROOT/.git/HEAD"
 
     GIT_SYNC \
@@ -2380,6 +2394,7 @@ function e2e::submodule_sync_default() {
     mkdir "$SUBMODULE"
 
     git -C "$SUBMODULE" init -q -b "$MAIN_BRANCH"
+    config_repo "$SUBMODULE"
     echo "submodule" > "$SUBMODULE/submodule"
     git -C "$SUBMODULE" add submodule
     git -C "$SUBMODULE" commit -aqm "init submodule file"
@@ -2390,6 +2405,7 @@ function e2e::submodule_sync_default() {
     mkdir "$NESTED_SUBMODULE"
 
     git -C "$NESTED_SUBMODULE" init -q -b "$MAIN_BRANCH"
+    config_repo "$NESTED_SUBMODULE"
     echo "nested-submodule" > "$NESTED_SUBMODULE/nested-submodule"
     git -C "$NESTED_SUBMODULE" add nested-submodule
     git -C "$NESTED_SUBMODULE" commit -aqm "init nested-submodule file"
@@ -2486,6 +2502,7 @@ function e2e::submodule_sync_depth() {
     mkdir "$SUBMODULE"
 
     git -C "$SUBMODULE" init -q -b "$MAIN_BRANCH"
+    config_repo "$SUBMODULE"
 
     # First sync
     expected_depth="1"
@@ -2566,6 +2583,7 @@ function e2e::submodule_sync_off() {
     mkdir "$SUBMODULE"
 
     git -C "$SUBMODULE" init -q -b "$MAIN_BRANCH"
+    config_repo "$SUBMODULE"
     echo "submodule" > "$SUBMODULE/submodule"
     git -C "$SUBMODULE" add submodule
     git -C "$SUBMODULE" commit -aqm "init submodule file"
@@ -2596,6 +2614,7 @@ function e2e::submodule_sync_shallow() {
     mkdir "$SUBMODULE"
 
     git -C "$SUBMODULE" init -q -b "$MAIN_BRANCH"
+    config_repo "$SUBMODULE"
     echo "submodule" > "$SUBMODULE/submodule"
     git -C "$SUBMODULE" add submodule
     git -C "$SUBMODULE" commit -aqm "init submodule file"
@@ -2606,6 +2625,7 @@ function e2e::submodule_sync_shallow() {
     mkdir "$NESTED_SUBMODULE"
 
     git -C "$NESTED_SUBMODULE" init -q -b "$MAIN_BRANCH"
+    config_repo "$NESTED_SUBMODULE"
     echo "nested-submodule" > "$NESTED_SUBMODULE/nested-submodule"
     git -C "$NESTED_SUBMODULE" add nested-submodule
     git -C "$NESTED_SUBMODULE" commit -aqm "init nested-submodule file"
@@ -2642,6 +2662,7 @@ function e2e::submodule_sync_relative() {
     mkdir "$SUBMODULE"
 
     git -C "$SUBMODULE" init -q -b "$MAIN_BRANCH"
+    config_repo "$SUBMODULE"
     echo "submodule" > "$SUBMODULE/submodule"
     git -C "$SUBMODULE" add submodule
     git -C "$SUBMODULE" commit -aqm "init submodule file"


### PR DESCRIPTION
Makes it easy for anyone to run tests on github, doesn't preclude us using prow also.

Second commit fixes an issue where we were relying on global git configuration, which didn't work in the isolated github CI environment.

Issue #424