### PR TITLE
Add linters to makefile/github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,3 +46,30 @@ jobs:
         working-directory: git-sync
         run: |
           make test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20.6'
+
+      - uses: actions/checkout@v3
+        with:
+          path: git-sync
+
+      # We run the github action, even though this is duplicated in `make lint` below.
+      # This is because the action gives easier-to-read output than the linter.
+      # There is a risk of drift between the two, but this is only linting,
+      # not runtime correctness!
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          working-directory: git-sync
+          version: v1.53.3
+
+      - name: make lint
+        working-directory: git-sync
+        run: |
+          make lint

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,26 @@
+# This file configures checks that all new code for Kubernetes is meant to
+# pass, in contrast to .golangci.yaml which defines checks that also the
+# existing code passes.
+
+run:
+  timeout: 30m
+
+linters:
+  disable-all: false
+  enable: # please keep this alphabetized
+    - ginkgolinter
+    - gocritic
+    - govet
+    - ineffassign
+    # Should we add logcheck, for consistency with kubernetes/kubernetes?
+    # - logcheck
+    - staticcheck
+    - stylecheck
+    - unused
+
+linters-settings: # please keep this alphabetized
+  gocritic:
+  staticcheck:
+    checks:
+      - "all"
+  stylecheck:

--- a/Makefile
+++ b/Makefile
@@ -276,3 +276,11 @@ container-clean:
 
 bin-clean:
 	rm -rf .go bin
+
+lint-staticcheck:
+	go run honnef.co/go/tools/cmd/staticcheck@2023.1.3
+
+lint-golangci-lint:
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3 run
+
+lint: lint-staticcheck lint-golangci-lint


### PR DESCRIPTION
Builds on #786, adds a linter task to the makefile and a task to the github actions CI.

I think if we merge #786, then this will run in github actions CI.

Issue #777 