### PR TITLE
Rename github build workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  build-linux-amd64:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Set up go


### PR DESCRIPTION
It says amd64, but calls all-build 