### PR TITLE
lint: fix remaining lint issues.

### DIFF
--- a/pkg/pid1/pid1.go
+++ b/pkg/pid1/pid1.go
@@ -69,7 +69,7 @@ func runInit(firstborn int) (int, error) {
 			if status.Exited() {
 				return status.ExitStatus(), nil
 			}
-			return 0, fmt.Errorf("unhandled exit status: 0x%x\n", status)
+			return 0, fmt.Errorf("unhandled exit status: 0x%x", status)
 		}
 	}
 	return 0, fmt.Errorf("signal handler terminated unexpectedly")
@@ -83,7 +83,7 @@ func sigchld(firstborn int) (bool, syscall.WaitStatus, error) {
 		var status syscall.WaitStatus
 		pid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
 		if err != nil {
-			return false, 0, fmt.Errorf("wait4(): %w\n", err)
+			return false, 0, fmt.Errorf("wait4(): %w", err)
 		}
 
 		if pid == firstborn {


### PR DESCRIPTION
These fix the issues identified by the k/k inspired linter
configuration that we will be adding:

```
pkg/pid1/pid1.go:72:14: ST1005: error strings should not end with punctuation or newlines (stylecheck)
                        return 0, fmt.Errorf("unhandled exit status: 0x%x\n", status)
                                  ^
pkg/pid1/pid1.go:86:21: ST1005: error strings should not end with punctuation or newlines (stylecheck)
                        return false, 0, fmt.Errorf("wait4(): %w\n", err)
                                         ^
main.go:480:34: Error return value of `pflag.CommandLine.MarkDeprecated` is not checked (errcheck)
        pflag.CommandLine.MarkDeprecated("branch", "use --ref instead")
                                        ^
main.go:483:34: Error return value of `pflag.CommandLine.MarkDeprecated` is not checked (errcheck)
        pflag.CommandLine.MarkDeprecated("change-permissions", "use --group-write instead")
                                        ^
main.go:486:34: Error return value of `pflag.CommandLine.MarkDeprecated` is not checked (errcheck)
        pflag.CommandLine.MarkDeprecated("dest", "use --link instead")
                                        ^
main.go:1897:16: Error return value of `io.WriteString` is not checked (errcheck)
        io.WriteString(h, s)
                      ^
main.go:555:2: ifElseChain: rewrite if-else to switch statement (gocritic)
        if *flDeprecatedBranch != "" && (*flDeprecatedRev == "" || *flDeprecatedRev == "HEAD") {
        ^
```
