### PR TITLE
Document V4 regression on --change-permissions

### DIFF
--- a/v3-to-v4.md
+++ b/v3-to-v4.md
@@ -104,8 +104,15 @@ specified.
 
 The old `--change-permissions` flag was poorly designed and not able to express
 the real intentions (e.g. "allow group write" does not mean "set everything to
-0775").  The new `--group-write` flag should cover what people ACTUALLY are
-trying to do.  The `--change-permissions` flag is no longer supported.
+0775").  The new `--group-write` flag should cover what most people ACTUALLY
+are trying to do.
+
+There is one case where `--change-permissions` was useful and `--group-write`
+is not - making non-executable files in the repo executable so they can be run
+as exechooks.  The proper solution here is to make the file executable in the
+repo, rather than changing it after checkout.
+
+The `--change-permissions` flag is no longer supported.
 
 ### Manual: `--man`
 


### PR DESCRIPTION
Possible docs-fix for #807 .  A real fix is either gross (bring back --change-permissions) or more complex (make a new flag which is more sophisticated, like `--chmod="glob=mode"`.  IMO, this belongs in the repo, not in the client.

For discussion