### PR TITLE
Deprecate --ssh - it's not really needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ OPTIONS
 
     --add-user, $GITSYNC_ADD_USER
             Add a record to /etc/passwd for the current UID/GID.  This is
-            needed to use SSH with an arbitrary UID (see --ssh).  This assumes
-            that /etc/passwd is writable by the current UID.
+            needed to use SSH with an arbitrary UID.  This assumes that
+            /etc/passwd is writable by the current UID.
 
     --askpass-url <string>, $GITSYNC_ASKPASS_URL
             A URL to query for git credentials.  The query must return success
@@ -313,18 +313,15 @@ OPTIONS
             details) which controls which files and directories will be checked
             out.  If not specified, the default is to check out the entire repo.
 
-    --ssh, $GITSYNC_SSH
-            Use SSH for git authentication and operations.
-
     --ssh-key-file <string>, $GITSYNC_SSH_KEY_FILE
-            The SSH key(s) to use when using --ssh.  This flag may be specified
-            more than once and the environment variable will be parsed like
-            PATH - using a colon (':') to separate elements.  If not specified,
-            this defaults to "/etc/git-secret/ssh".
+            The SSH key(s) to use when using git over SSH.  This flag may be
+            specified more than once and the environment variable will be
+            parsed like PATH - using a colon (':') to separate elements.  If
+            not specified, this defaults to "/etc/git-secret/ssh".
 
     --ssh-known-hosts, $GITSYNC_SSH_KNOWN_HOSTS
-            Enable SSH known_hosts verification when using --ssh.  If not
-            specified, this defaults to true.
+            Enable SSH known_hosts verification when using git over SSH.  If
+            not specified, this defaults to true.
 
     --ssh-known-hosts-file <string>, $GITSYNC_SSH_KNOWN_HOSTS_FILE
             The known_hosts file to use when --ssh-known-hosts is specified.
@@ -430,11 +427,11 @@ AUTHENTICATION
             sync.
 
     SSH
-            When --ssh (GITSYNC_SSH) is specified, the --ssh-key-file
-            (GITSYNC_SSH_KEY_FILE) will be used.  Users are strongly advised
-            to also use --ssh-known-hosts (GITSYNC_SSH_KNOWN_HOSTS) and
-            --ssh-known-hosts-file (GITSYNC_SSH_KNOWN_HOSTS_FILE) when using
-            SSH.
+            When an SSH transport is specified, the key(s) defined in
+            --ssh-key-file (GITSYNC_SSH_KEY_FILE) will be used.  Users are
+            strongly advised to also use --ssh-known-hosts
+            (GITSYNC_SSH_KNOWN_HOSTS) and --ssh-known-hosts-file
+            (GITSYNC_SSH_KNOWN_HOSTS_FILE) when using SSH.
 
     cookies
             When --cookie-file (GITSYNC_COOKIE_FILE) is specified, the

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -69,11 +69,11 @@ Secret (e.g. "git-creds" used in both above examples).
 ## Step 3: Configure git-sync container
 
 In your git-sync container configuration, mount the Secret volume at
-"/etc/git-secret". Ensure that the `--repo` flag (or the GITSYNC_REPO
+"/etc/git-secret". Ensure that the `--repo` flag (or the `GITSYNC_REPO`
 environment variable) is set to use the SSH protocol (e.g.
-git@github.com/foo/bar) , and set the `--ssh` flags (or set GITSYNC_SSH to
-"true").  You will also need to set your container's `securityContext` to run
-as user ID "65533" which is created for running git-sync as non-root.
+git@github.com/foo/bar).  You will also need to set your container's
+`securityContext` to run as user ID "65533" which is created for running
+git-sync as non-root.
 
 ```yaml
       # ...
@@ -81,7 +81,6 @@ as user ID "65533" which is created for running git-sync as non-root.
       - name: git-sync
         image: registry.k8s.io/git-sync:v4.0.0
         args:
-         - "--ssh"
          - "--repo=git@github.com:foo/bar"
          - "--link=bar"
         volumeMounts:
@@ -139,7 +138,6 @@ spec:
       - name: git-sync
         image: registry.k8s.io/git-sync:v4.0.0
         args:
-         - "--ssh"
          - "--repo=git@github.com:torvalds/linux"
          - "--depth=1"
         securityContext:

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -1713,7 +1713,6 @@ function e2e::auth_ssh() {
             --repo="test@$IP:/git/repo" \
             --root="$ROOT" \
             --link="link" \
-            --ssh \
             --ssh-known-hosts=false \
             --ssh-key-file="/ssh/secret.2"
     assert_file_absent "$ROOT/link/file"
@@ -1724,7 +1723,6 @@ function e2e::auth_ssh() {
         --repo="test@$IP:/git/repo" \
         --root="$ROOT" \
         --link="link" \
-        --ssh \
         --ssh-known-hosts=false \
         --ssh-key-file="/ssh/secret.1" \
         --ssh-key-file="/ssh/secret.2" \
@@ -2724,7 +2722,6 @@ function e2e::submodule_sync_over_ssh_different_keys() {
         --repo="test@$IP:/git/repo" \
         --root="$ROOT" \
         --link="link" \
-        --ssh \
         --ssh-key-file="/ssh/secret.1" \
         --ssh-key-file="/ssh/secret.2" \
         --ssh-key-file="/ssh/secret.3" \

--- a/v3-to-v4.md
+++ b/v3-to-v4.md
@@ -107,6 +107,11 @@ the real intentions (e.g. "allow group write" does not mean "set everything to
 0775").  The new `--group-write` flag should cover what people ACTUALLY are
 trying to do.  The `--change-permissions` flag is no longer supported.
 
+### SSH: `--ssh`
+
+The old `--ssh` flag is no longer needed - the value of `--repo` determines
+when SSH is used.  It is still accepted but does nothing.
+
 ### Manual: `--man`
 
 The new `--man` flag prints a man-page style help document and exits.


### PR DESCRIPTION
As long as a repo uses SSH transport (user@host:path or ssh://...), SSH is active.  This is true for the main repo or submodules.