### PR TITLE
Fix errors when parsing --repo for logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -1274,7 +1274,9 @@ func redactURL(urlstr string) string {
 		return err.Error()
 	}
 	if u.User != nil {
-		u.User = url.UserPassword(u.User.Username(), redactedString)
+		if _, found := u.User.Password(); found {
+			u.User = url.UserPassword(u.User.Username(), redactedString)
+		}
 	}
 	return u.String()
 }

--- a/main.go
+++ b/main.go
@@ -1271,7 +1271,8 @@ const redactedString = "REDACTED"
 func redactURL(urlstr string) string {
 	u, err := url.Parse(urlstr)
 	if err != nil {
-		return err.Error()
+		// May be something like user@git.example.com:path/to/repo
+		return urlstr
 	}
 	if u.User != nil {
 		if _, found := u.User.Password(); found {


### PR DESCRIPTION
Only redact the URL password if it was actually provided.

If --repo is not a valid URL (e.g. user@host:path is a valid repo, but not a URL) , it's not an error, just log it.

Fixes #826 