### PR TITLE
Simplify inner loop: just fetch $ref

### DIFF
--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -3021,7 +3021,7 @@ function e2e::export_error() {
             --error-file="error.json"
         assert_file_absent "$ROOT/link"
         assert_file_absent "$ROOT/link/file"
-        assert_file_contains "$ROOT/error.json" "unknown revision"
+        assert_file_contains "$ROOT/error.json" "couldn't find remote ref"
 
     # the error.json file should be removed if sync succeeds.
     GIT_SYNC \
@@ -3049,7 +3049,7 @@ function e2e::export_error_abs_path() {
             --error-file="$ROOT/dir/error.json"
         assert_file_absent "$ROOT/link"
         assert_file_absent "$ROOT/link/file"
-        assert_file_contains "$ROOT/dir/error.json" "unknown revision"
+        assert_file_contains "$ROOT/dir/error.json" "couldn't find remote ref"
 }
 
 ##############################################

--- a/v3-to-v4.md
+++ b/v3-to-v4.md
@@ -31,6 +31,14 @@ commit (by SHA) it needs.  This transfers less data and closes the race
 condition where a symbolic name can change after `git ls-remote` but before
 `git fetch`.
 
+### The v4.2+ loop
+
+The v4.2 loop refines the v4 loop even further.  Instead of using ls-remote to
+see what the upstream has and then fetching it, git-sync sill just fetch it by
+ref.  If the local sync already has the corresponding hash, nothing more will
+be synced.  If it did not have that hash before, then it does now and can
+update the worktree.
+
 ## Flags
 
 The flag syntax parsing has changed in v4.  git-sync v3 accept flags in Go's


### PR DESCRIPTION
Fixes #844

Old way:
  - ls-remote $ref $ref^{} and parse
  - compare to current
  - if changed, fetch
  - update worktree

New way:
  - fetch $ref
  - compare to current
  - if change, update worktree