### PR TITLE
chore: fix missing unit duration in the k8s example

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -39,7 +39,7 @@ spec:
           args:
             - --repo=https://github.com/kubernetes/git-sync
             - --depth=1
-            - --period=60
+            - --period=60s
             - --link=current
             - --root=/git
           volumeMounts:


### PR DESCRIPTION
Using the example the git-sync sidecar exits and logs:
```
INFO: detected pid 1, running init handler
invalid argument "60" for "--period" flag: time: missing unit in duration "60"
Usage of /git-sync:
```