### PR TITLE
Fix: Use hugo mod get

### DIFF
--- a/demo/blog/config.toml
+++ b/demo/blog/config.toml
@@ -1,3 +1,8 @@
 baseurl = "http://example.com"
 languageCode = "en-us"
 title = "example blog"
+
+[module]
+[[module.imports]]
+  path = "github.com/spf13/hyde"
+  disabled=false

--- a/demo/blog/go.mod
+++ b/demo/blog/go.mod
@@ -1,0 +1,3 @@
+module blog
+
+go 1.22.2

--- a/demo/hugo/Dockerfile
+++ b/demo/hugo/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2024 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 FROM golang
-RUN go get -v github.com/spf13/hugo
-RUN git clone --recursive https://github.com/spf13/hugoThemes.git /themes
+RUN go install -v github.com/gohugoio/hugo@latest
 VOLUME ["/src", "/dest"]
 EXPOSE 1313
 ENV HUGO_SRC /src
 ENV HUGO_DEST /dest
-ENV HUGO_THEME hyde
 ENV HUGO_BUILD_DRAFT false
 ENV HUGO_BASE_URL ""
+WORKDIR ${HUGO_SRC}
 ADD run-hugo /run-hugo
 ENTRYPOINT ["/run-hugo"]
-CMD ["server", "--source=${HUGO_SRC}", "--theme=${HUGO_THEME}", "--buildDrafts=${HUGO_BUILD_DRAFT}", "--baseUrl=${HUGO_BASE_URL}", "--watch", "--destination=${HUGO_DEST}", "--appendPort=false"]
+CMD ["server", "--source=${HUGO_SRC}", "--buildDrafts=${HUGO_BUILD_DRAFT}", "--baseURL=${HUGO_BASE_URL}", "--watch", "--destination=${HUGO_DEST}", "--appendPort=false"]

--- a/demo/hugo/Dockerfile
+++ b/demo/hugo/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2024 Google Inc. All rights reserved.
+# Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/demo/hugo/run-hugo
+++ b/demo/hugo/run-hugo
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 Google Inc. All rights reserved.
+# Copyright 2024 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 set -ex
-if [ ! -d ${HUGO_SRC}/themes ]; then
-    ln -s /themes ${HUGO_SRC}/themes
-fi
+
+hugo mod -v get ./...
 hugo $(eval echo $*) # force default CMD env expansion

--- a/demo/hugo/run-hugo
+++ b/demo/hugo/run-hugo
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2024 Google Inc. All rights reserved.
+# Copyright 2014 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Recently hugo does not support hugoThemes and some themes are already missing. In the latest hugo, themes are treated as modules. So this change fixes that themes are retrieved in realtime with hugo mod get.