### PR TITLE
Fix new github actions e2e failure

### DIFF
--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -3541,6 +3541,14 @@ if [[ -n "${VERBOSE:-}" ]]; then
 fi
 echo
 
+# Log some info
+if [[ -n "${VERBOSE:-}" ]]; then
+    git version
+    echo
+    docker version
+    echo
+fi
+
 # Iterate over the chosen tests and run them.
 for t; do
     TEST_FN="e2e::${t}"


### PR DESCRIPTION
Tests worked 4 days ago, no committed changes since then.  Now fails with:

`testcase webhook_fail_retry: FAIL`

```
docker: Error response from daemon: invalid config for network bridge: invalid endpoint settings:
user specified IP address is supported on user defined networks only.
See 'docker run --help'.
```

We have exactly one testcase that needs this (`docker run --ip`).  It used to work and now it doesn't.  It looks like maybe `--ip` NEVER worked but just didn't error before.