### PR TITLE
test_e2e.sh: quote variables to prevent globbing and word splitting

### DIFF
--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -761,9 +761,9 @@ function e2e::stale_worktree_timeout() {
 
     # wait for first sync
     wait_for_sync "${MAXWAIT}"
-    assert_link_exists "$ROOT"/link
-    assert_file_exists "$ROOT"/link/file
-    assert_file_eq "$ROOT"/link/file "$FUNCNAME 1"
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_eq "$ROOT/link/file" "$FUNCNAME 1"
 
     # wait 2 seconds and make another commit
     sleep 2
@@ -776,11 +776,11 @@ function e2e::stale_worktree_timeout() {
     wait_for_sync "${MAXWAIT}"
     # at this point both WT1 and WT2 should exist, with
     # link pointing to the new WT2
-    assert_link_exists "$ROOT"/link
-    assert_file_exists "$ROOT"/link/file
-    assert_file_exists "$ROOT"/link/file2
-    assert_file_exists "$ROOT"/.worktrees/$WT1/file
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file2
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/file2"
+    assert_file_exists "$ROOT/.worktrees/$WT1/file"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file2"
 
     # wait 2 seconds and make a third commit
     sleep 2
@@ -793,57 +793,57 @@ function e2e::stale_worktree_timeout() {
 
     # at this point WT1, WT2, WT3 should exist, with
     # link pointing to WT3
-    assert_link_exists "$ROOT"/link
-    assert_file_exists "$ROOT"/link/file
-    assert_file_exists "$ROOT"/link/file2
-    assert_file_exists "$ROOT"/link/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT1/file
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT2/file
-    assert_file_exists "$ROOT"/.worktrees/$WT2/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT2/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file2
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file3
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/file2"
+    assert_file_exists "$ROOT/link/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT1/file"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT2/file"
+    assert_file_exists "$ROOT/.worktrees/$WT2/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT2/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file2"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file3"
 
     # wait for WT1 to go stale
     sleep 4
 
     # now WT1 should be stale and deleted,
     # WT2 and WT3 should still exist
-    assert_link_exists "$ROOT"/link
-    assert_file_exists "$ROOT"/link/file
-    assert_file_exists "$ROOT"/link/file2
-    assert_file_exists "$ROOT"/link/file3
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT2/file
-    assert_file_exists "$ROOT"/.worktrees/$WT2/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT2/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file2
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file3
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/file2"
+    assert_file_exists "$ROOT/link/file3"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT2/file"
+    assert_file_exists "$ROOT/.worktrees/$WT2/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT2/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file2"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file3"
 
     # wait for WT2 to go stale
     sleep 2
 
     # now both WT1 and WT2 are stale, WT3 should be the only
     # worktree left
-    assert_link_exists "$ROOT"/link
-    assert_file_exists "$ROOT"/link/file
-    assert_file_exists "$ROOT"/link/file2
-    assert_file_exists "$ROOT"/link/file3
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file3
-    assert_file_absent "$ROOT"/.worktrees/$WT2/file
-    assert_file_absent "$ROOT"/.worktrees/$WT2/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT2/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file2
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file3
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/file2"
+    assert_file_exists "$ROOT/link/file3"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file3"
+    assert_file_absent "$ROOT/.worktrees/$WT2/file"
+    assert_file_absent "$ROOT/.worktrees/$WT2/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT2/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file2"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file3"
 }
 
 ##############################################
@@ -859,9 +859,9 @@ function e2e::stale_worktree_timeout_restart() {
         --link="link" \
         --one-time
 
-    assert_link_exists "$ROOT"/link
-    assert_file_exists "$ROOT"/link/file
-    assert_file_eq "$ROOT"/link/file "$FUNCNAME 1"
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_eq "$ROOT/link/file" "$FUNCNAME 1"
 
     # wait 2 seconds and make another commit
     sleep 2
@@ -880,11 +880,11 @@ function e2e::stale_worktree_timeout_restart() {
 
     # at this point both WT1 and WT2 should exist, with
     # link pointing to the new WT2
-    assert_link_exists "$ROOT"/link
-    assert_file_exists "$ROOT"/link/file
-    assert_file_exists "$ROOT"/link/file2
-    assert_file_exists "$ROOT"/.worktrees/$WT1/file
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file2
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/file2"
+    assert_file_exists "$ROOT/.worktrees/$WT1/file"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file2"
 
     # wait 2 seconds and make a third commit
     sleep 4
@@ -903,19 +903,19 @@ function e2e::stale_worktree_timeout_restart() {
 
     # at this point WT1, WT2, WT3 should exist, with
     # link pointing to WT3
-    assert_link_exists "$ROOT"/link
-    assert_file_exists "$ROOT"/link/file
-    assert_file_exists "$ROOT"/link/file2
-    assert_file_exists "$ROOT"/link/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT1/file
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT2/file
-    assert_file_exists "$ROOT"/.worktrees/$WT2/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT2/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file2
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file3
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/file2"
+    assert_file_exists "$ROOT/link/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT1/file"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT2/file"
+    assert_file_exists "$ROOT/.worktrees/$WT2/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT2/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file2"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file3"
 
     # wait for WT1 to go stale and restart git-sync
     sleep 8
@@ -928,19 +928,19 @@ function e2e::stale_worktree_timeout_restart() {
 
     # now WT1 should be stale and deleted,
     # WT2 and WT3 should still exist
-    assert_link_exists "$ROOT"/link
-    assert_file_exists "$ROOT"/link/file
-    assert_file_exists "$ROOT"/link/file2
-    assert_file_exists "$ROOT"/link/file3
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT2/file
-    assert_file_exists "$ROOT"/.worktrees/$WT2/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT2/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file2
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file3
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/file2"
+    assert_file_exists "$ROOT/link/file3"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT2/file"
+    assert_file_exists "$ROOT/.worktrees/$WT2/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT2/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file2"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file3"
 
     # wait for WT2 to go stale and restart git-sync
     sleep 4
@@ -953,19 +953,19 @@ function e2e::stale_worktree_timeout_restart() {
 
     # now both WT1 and WT2 are stale, WT3 should be the only
     # worktree left
-    assert_link_exists "$ROOT"/link
-    assert_file_exists "$ROOT"/link/file
-    assert_file_exists "$ROOT"/link/file2
-    assert_file_exists "$ROOT"/link/file3
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT1/file3
-    assert_file_absent "$ROOT"/.worktrees/$WT2/file
-    assert_file_absent "$ROOT"/.worktrees/$WT2/file2
-    assert_file_absent "$ROOT"/.worktrees/$WT2/file3
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file2
-    assert_file_exists "$ROOT"/.worktrees/$WT3/file3
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/file2"
+    assert_file_exists "$ROOT/link/file3"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT1/file3"
+    assert_file_absent "$ROOT/.worktrees/$WT2/file"
+    assert_file_absent "$ROOT/.worktrees/$WT2/file2"
+    assert_file_absent "$ROOT/.worktrees/$WT2/file3"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file2"
+    assert_file_exists "$ROOT/.worktrees/$WT3/file3"
 }
 
 ##############################################

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -72,7 +72,7 @@ function assert_link_basename_eq() {
     if [[ $(basename $(readlink "$1")) == "$2" ]]; then
         return
     fi
-    fail "$1 does not point to $2: $(readlink $1)"
+    fail "$1 does not point to $2: $(readlink "$1")"
 }
 
 function assert_file_exists() {
@@ -91,14 +91,14 @@ function assert_file_eq() {
     if [[ $(cat "$1") == "$2" ]]; then
         return
     fi
-    fail "$1 does not contain '$2': $(cat $1)"
+    fail "$1 does not contain '$2': $(cat "$1")"
 }
 
 function assert_file_contains() {
     if grep -q "$2" "$1"; then
         return
     fi
-    fail "$1 does not contain '$2': $(cat $1)"
+    fail "$1 does not contain '$2': $(cat "$1")"
 }
 
 function assert_file_lines_eq() {
@@ -2869,7 +2869,7 @@ function e2e::submodule_sync_relative() {
 
     # Add submodule
     REL="$(realpath --relative-to "$REPO" "$WORK/$SUBMODULE_REPO_NAME")"
-    echo $REL
+    echo "$REL"
     git -C "$REPO" -c protocol.file.allow=always submodule add -q "$REL" "$SUBMODULE_REPO_NAME"
     git -C "$REPO" commit -aqm "add submodule"
 
@@ -3411,7 +3411,7 @@ function list_tests() {
         declare -F \
             | cut -f3 -d' ' \
             | grep "^e2e::" \
-            | while read X; do declare -F $X; done \
+            | while read X; do declare -F "$X"; done \
             | sort -n -k2 \
             | cut -f1 -d' ' \
             | sed 's/^e2e:://'


### PR DESCRIPTION
Fixes SC2086. Part of #891. 

```
git-sync#fix-e2e-sc2086> shellcheck -i SC2086 test_e2e.sh  && echo $?
0
```
As explained in 390f63cc6ed458955d0d66567ee5faa97cdf6106, some strings don't require to be fully quoted, but doing
so anyway to keep code consistency. 
