### PR TITLE
consistently use bash shebang for shell scripts

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #


### PR DESCRIPTION
This updates the build scripts to use a bash shebang for consistency with other scripts as well as better portability. If using a non-alpine BUILDIMAGE (e.g. debian) the build scripts are not valid sh syntax.