### PR TITLE
consistently use bash shebang for shell scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)
 OS_ARCH_TAG := $(TAG)__$(OS)_$(ARCH)
 
-BUILD_IMAGE ?= golang:1.22-alpine
+BUILD_IMAGE ?= golang:1.22
 
 DBG_MAKEFILE ?=
 ifneq ($(DBG_MAKEFILE),1)

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #


### PR DESCRIPTION
This updates the build scripts to use a bash shebang for consistency with other scripts as well as better portability. If using a non-alpine BUILDIMAGE (e.g. debian) the build scripts are not valid sh syntax.

Also updates BUILDIMAGE to use the debian based golang image for consistency with BASEIMAGE. The debian based golang image also comes with bash installed, whereas the alpine base image does not.