### PR TITLE
use debian build image and bash build scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ IMAGE := $(REGISTRY)/$(BIN)
 TAG := $(VERSION)
 OS_ARCH_TAG := $(TAG)__$(OS)_$(ARCH)
 
-BUILD_IMAGE ?= golang:1.22-alpine
+BUILD_IMAGE ?= golang:1.22
 
 DBG_MAKEFILE ?=
 ifneq ($(DBG_MAKEFILE),1)

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/build/build.sh
+++ b/build/build.sh
@@ -16,6 +16,7 @@
 
 set -o errexit
 set -o nounset
+set -o pipefail
 
 if [ -z "${ARCH:-}" ]; then
     echo "ARCH must be set"
@@ -34,7 +35,7 @@ export CGO_ENABLED=0
 export GOARCH="${ARCH}"
 export GOOS="${OS}"
 
-if [ "${BUILD_DEBUG:-0}" -eq 1 ]; then
+if [[ "${BUILD_DEBUG:-0}" == 1 ]]; then
     # Debugging - disable optimizations and inlining
     gogcflags="all=-N -l"
     goasmflags=""

--- a/build/test.sh
+++ b/build/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright 2016 The Kubernetes Authors.
 #

--- a/build/test.sh
+++ b/build/test.sh
@@ -16,6 +16,7 @@
 
 set -o errexit
 set -o nounset
+set -o pipefail
 
 export CGO_ENABLED=0
 export GOFLAGS="-mod=vendor"
@@ -24,7 +25,7 @@ echo "Running tests:"
 go test -installsuffix "static" "$@"
 echo
 
-echo "Checking gofmt: "
+echo -n "Checking gofmt: "
 ERRS="$(go fmt "$@")"
 if [ -n "${ERRS}" ]; then
     echo "FAIL - the following files need to be gofmt'ed:"
@@ -37,7 +38,7 @@ fi
 echo "PASS"
 echo
 
-echo "Checking go vet: "
+echo -n "Checking go vet: "
 ERRS="$(go vet "$@" 2>&1 || true)"
 if [ -n "${ERRS}" ]; then
     echo "FAIL"


### PR DESCRIPTION
This makes several changes to the build environment in the interest of consistency:
- Changes the build image to use a debian based image for consistency with the BASEIMAGE
- Changes the build scripts to use bash for consistency with other scripts in the repo