### PR TITLE
test_e2e.sh: shellcheck entire file

### DIFF
--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -50,12 +50,12 @@ function wait_for_file_exists() {
     local file=$1
     local ticks=$(($2*10)) # 100ms per tick
 
-    while (( $ticks > 0 )); do
+    while (( ticks > 0 )); do
         if [[ -f "$file" ]]; then
             break
         fi
         sleep 0.1
-        ticks=$(($ticks-1))
+        ticks=$((ticks-1))
     done
 }
 

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -18,6 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# shellcheck disable=SC2120
 function caller() {
   local stack_skip=${1:-0}
   stack_skip=$((stack_skip + 1))

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -36,7 +36,7 @@ function caller() {
 }
 
 function fail() {
-    echo "FAIL: line $(caller):" "$@" >&3
+    echo "FAIL: line $(caller "$@"):" "$@" >&3
     return 42
 }
 

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -305,7 +305,7 @@ function GIT_SYNC() {
 function remove_containers() {
     sleep 2 # Let docker finish saving container metadata
     docker ps --filter label="git-sync-e2e=$RUNID" --format="{{.ID}}" \
-        | while read CTR; do
+        | while read -r CTR; do
             docker kill "$CTR" >/dev/null
         done
 }
@@ -620,7 +620,7 @@ function e2e::worktree_cleanup() {
 
     # suspend time so we can fake corruption
     docker ps --filter label="git-sync-e2e=$RUNID" --format="{{.ID}}" \
-        | while read CTR; do
+        | while read -r CTR; do
             docker pause "$CTR" >/dev/null
         done
 
@@ -640,7 +640,7 @@ function e2e::worktree_cleanup() {
 
     # resume time
     docker ps --filter label="git-sync-e2e=$RUNID" --format="{{.ID}}" \
-        | while read CTR; do
+        | while read -r CTR; do
             docker unpause "$CTR" >/dev/null
         done
 
@@ -675,7 +675,7 @@ function e2e::worktree_unexpected_removal() {
 
     # suspend time so we can fake corruption
     docker ps --filter label="git-sync-e2e=$RUNID" --format="{{.ID}}" \
-        | while read CTR; do
+        | while read -r CTR; do
             docker pause "$CTR" >/dev/null
         done
 
@@ -685,7 +685,7 @@ function e2e::worktree_unexpected_removal() {
 
     # resume time
     docker ps --filter label="git-sync-e2e=$RUNID" --format="{{.ID}}" \
-        | while read CTR; do
+        | while read -r CTR; do
             docker unpause "$CTR" >/dev/null
         done
 
@@ -718,7 +718,7 @@ function e2e::sync_recover_wrong_worktree_hash() {
 
     # suspend time so we can fake corruption
     docker ps --filter label="git-sync-e2e=$RUNID" --format="{{.ID}}" \
-        | while read CTR; do
+        | while read -r CTR; do
             docker pause "$CTR" >/dev/null
         done
 
@@ -728,7 +728,7 @@ function e2e::sync_recover_wrong_worktree_hash() {
 
     # resume time
     docker ps --filter label="git-sync-e2e=$RUNID" --format="{{.ID}}" \
-        | while read CTR; do
+        | while read -r CTR; do
             docker unpause "$CTR" >/dev/null
         done
 
@@ -3406,7 +3406,7 @@ function list_tests() {
         declare -F \
             | cut -f3 -d' ' \
             | grep "^e2e::" \
-            | while read X; do declare -F "$X"; done \
+            | while read -r X; do declare -F "$X"; done \
             | sort -n -k2 \
             | cut -f1 -d' ' \
             | sed 's/^e2e:://'

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -36,7 +36,7 @@ function caller() {
 }
 
 function fail() {
-    echo "FAIL: line $(caller "$@"):" "$@" >&3
+    echo "FAIL: line $(caller):" "$@" >&3
     return 42
 }
 

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -2977,6 +2977,7 @@ function e2e::submodule_sync_over_http_different_passwords() {
     git -C "$NESTED_SUBMODULE" commit -aqm "init nested-submodule.file"
 
     # Run a git-over-SSH server.  Use password "test1".
+    # shellcheck disable=SC2016
     echo 'test:$apr1$cXiFWR90$Pmoz7T8kEmlpC9Bpj4MX3.' > "$WORK/htpasswd.1"
     CTR_SUBSUB=$(docker_run \
         -v "$NESTED_SUBMODULE":/git/repo:ro \
@@ -3000,6 +3001,7 @@ function e2e::submodule_sync_over_http_different_passwords() {
     git -C "$SUBMODULE" commit -aqm "add nested submodule"
 
     # Run a git-over-SSH server.  Use password "test2".
+    # shellcheck disable=SC2016
     echo 'test:$apr1$vWBoWUBS$2H.WFxF8T7rH/gZF99Edl/' > "$WORK/htpasswd.2"
     CTR_SUB=$(docker_run \
         -v "$SUBMODULE":/git/repo:ro \
@@ -3014,6 +3016,7 @@ function e2e::submodule_sync_over_http_different_passwords() {
     git -C "$REPO" submodule update --recursive --remote > /dev/null 2>&1
 
     # Run a git-over-SSH server.  Use password "test3".
+    # shellcheck disable=SC2016
     echo 'test:$apr1$oKP2oGwp$ESJ4FESEP/8Sisy02B/vM/' > "$WORK/htpasswd.3"
     CTR=$(docker_run \
         -v "$REPO":/git/repo:ro \

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -1658,7 +1658,7 @@ function e2e::sync_depth_across_updates() {
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 1
     assert_metric_eq "${METRIC_FETCH_COUNT}" 1
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != $depth ]]; then
+    if [[ $expected_depth != "$depth" ]]; then
         fail "initial: expected depth $expected_depth, got $depth"
     fi
 
@@ -1672,7 +1672,7 @@ function e2e::sync_depth_across_updates() {
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 2
     assert_metric_eq "${METRIC_FETCH_COUNT}" 2
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != $depth ]]; then
+    if [[ $expected_depth != "$depth" ]]; then
         fail "forward: expected depth $expected_depth, got $depth"
     fi
 
@@ -1685,7 +1685,7 @@ function e2e::sync_depth_across_updates() {
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 3
     assert_metric_eq "${METRIC_FETCH_COUNT}" 3
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != $depth ]]; then
+    if [[ $expected_depth != "$depth" ]]; then
         fail "backward: expected depth $expected_depth, got $depth"
     fi
 }
@@ -2726,11 +2726,11 @@ function e2e::submodule_sync_depth() {
     assert_file_eq "$ROOT/link/$SUBMODULE_REPO_NAME/submodule.file" "${FUNCNAME[0]} 1"
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 1
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != $depth ]]; then
+    if [[ $expected_depth != "$depth" ]]; then
         fail "initial depth mismatch expected=$expected_depth actual=$depth"
     fi
     submodule_depth=$(git -C "$ROOT/link/$SUBMODULE_REPO_NAME" rev-list HEAD | wc -l)
-    if [[ $expected_depth != $submodule_depth ]]; then
+    if [[ $expected_depth != "$submodule_depth" ]]; then
         fail "initial submodule depth mismatch expected=$expected_depth actual=$submodule_depth"
     fi
 
@@ -2745,11 +2745,11 @@ function e2e::submodule_sync_depth() {
     assert_file_eq "$ROOT/link/$SUBMODULE_REPO_NAME/submodule.file" "${FUNCNAME[0]} 2"
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 2
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != $depth ]]; then
+    if [[ $expected_depth != "$depth" ]]; then
         fail "forward depth mismatch expected=$expected_depth actual=$depth"
     fi
     submodule_depth=$(git -C "$ROOT/link/$SUBMODULE_REPO_NAME" rev-list HEAD | wc -l)
-    if [[ $expected_depth != $submodule_depth ]]; then
+    if [[ $expected_depth != "$submodule_depth" ]]; then
         fail "forward submodule depth mismatch expected=$expected_depth actual=$submodule_depth"
     fi
 
@@ -2763,11 +2763,11 @@ function e2e::submodule_sync_depth() {
     assert_file_eq "$ROOT/link/$SUBMODULE_REPO_NAME/submodule.file" "${FUNCNAME[0]} 1"
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 3
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != $depth ]]; then
+    if [[ $expected_depth != "$depth" ]]; then
         fail "initial depth mismatch expected=$expected_depth actual=$depth"
     fi
     submodule_depth=$(git -C "$ROOT/link/$SUBMODULE_REPO_NAME" rev-list HEAD | wc -l)
-    if [[ $expected_depth != $submodule_depth ]]; then
+    if [[ $expected_depth != "$submodule_depth" ]]; then
         fail "initial submodule depth mismatch expected=$expected_depth actual=$submodule_depth"
     fi
     rm -rf $SUBMODULE

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -3497,7 +3497,8 @@ function run_test() {
     shift
 
     declare -g "$retvar"
-    local restore_opts=$(set +o)
+    local restore_opts
+    restore_opts=$(set +o)
     set +o errexit
     set +o nounset
     set +o pipefail

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -1658,7 +1658,7 @@ function e2e::sync_depth_across_updates() {
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 1
     assert_metric_eq "${METRIC_FETCH_COUNT}" 1
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != "$depth" ]]; then
+    if [[ "$expected_depth" != "$depth" ]]; then
         fail "initial: expected depth $expected_depth, got $depth"
     fi
 
@@ -1672,7 +1672,7 @@ function e2e::sync_depth_across_updates() {
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 2
     assert_metric_eq "${METRIC_FETCH_COUNT}" 2
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != "$depth" ]]; then
+    if [[ "$expected_depth" != "$depth" ]]; then
         fail "forward: expected depth $expected_depth, got $depth"
     fi
 
@@ -1685,7 +1685,7 @@ function e2e::sync_depth_across_updates() {
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 3
     assert_metric_eq "${METRIC_FETCH_COUNT}" 3
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != "$depth" ]]; then
+    if [[ "$expected_depth" != "$depth" ]]; then
         fail "backward: expected depth $expected_depth, got $depth"
     fi
 }
@@ -2726,11 +2726,11 @@ function e2e::submodule_sync_depth() {
     assert_file_eq "$ROOT/link/$SUBMODULE_REPO_NAME/submodule.file" "${FUNCNAME[0]} 1"
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 1
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != "$depth" ]]; then
+    if [[ "$expected_depth" != "$depth" ]]; then
         fail "initial depth mismatch expected=$expected_depth actual=$depth"
     fi
     submodule_depth=$(git -C "$ROOT/link/$SUBMODULE_REPO_NAME" rev-list HEAD | wc -l)
-    if [[ $expected_depth != "$submodule_depth" ]]; then
+    if [[ "$expected_depth" != "$submodule_depth" ]]; then
         fail "initial submodule depth mismatch expected=$expected_depth actual=$submodule_depth"
     fi
 
@@ -2745,11 +2745,11 @@ function e2e::submodule_sync_depth() {
     assert_file_eq "$ROOT/link/$SUBMODULE_REPO_NAME/submodule.file" "${FUNCNAME[0]} 2"
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 2
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != "$depth" ]]; then
+    if [[ "$expected_depth" != "$depth" ]]; then
         fail "forward depth mismatch expected=$expected_depth actual=$depth"
     fi
     submodule_depth=$(git -C "$ROOT/link/$SUBMODULE_REPO_NAME" rev-list HEAD | wc -l)
-    if [[ $expected_depth != "$submodule_depth" ]]; then
+    if [[ "$expected_depth" != "$submodule_depth" ]]; then
         fail "forward submodule depth mismatch expected=$expected_depth actual=$submodule_depth"
     fi
 
@@ -2763,11 +2763,11 @@ function e2e::submodule_sync_depth() {
     assert_file_eq "$ROOT/link/$SUBMODULE_REPO_NAME/submodule.file" "${FUNCNAME[0]} 1"
     assert_metric_eq "${METRIC_GOOD_SYNC_COUNT}" 3
     depth=$(git -C "$ROOT/link" rev-list HEAD | wc -l)
-    if [[ $expected_depth != "$depth" ]]; then
+    if [[ "$expected_depth" != "$depth" ]]; then
         fail "initial depth mismatch expected=$expected_depth actual=$depth"
     fi
     submodule_depth=$(git -C "$ROOT/link/$SUBMODULE_REPO_NAME" rev-list HEAD | wc -l)
-    if [[ $expected_depth != "$submodule_depth" ]]; then
+    if [[ "$expected_depth" != "$submodule_depth" ]]; then
         fail "initial submodule depth mismatch expected=$expected_depth actual=$submodule_depth"
     fi
     rm -rf $SUBMODULE

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -3444,7 +3444,7 @@ for arg; do
         if [[ "${t}" =~ ${arg} ]]; then
             nmatches=$((nmatches+1))
             # Don't run tests twice, just keep the first match.
-            if [[ " ${tests_to_run[*]} " =~ " ${t} " ]]; then
+            if [[ " ${tests_to_run[*]} " == *" ${t} "* ]]; then
                 continue
             fi
             tests_to_run+=("${t}")

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -69,7 +69,7 @@ function assert_link_exists() {
 }
 
 function assert_link_basename_eq() {
-    if [[ $(basename $(readlink "$1")) == "$2" ]]; then
+    if [[ $(basename "$(readlink "$1")") == "$2" ]]; then
         return
     fi
     fail "$1 does not point to $2: $(readlink "$1")"
@@ -279,7 +279,7 @@ function GIT_SYNC() {
         ${RM} \
         --label git-sync-e2e="$RUNID" \
         --network="host" \
-        -u git-sync:$(id -g) `# rely on GID, triggering "dubious ownership"` \
+        -u git-sync:"$(id -g)" `# rely on GID, triggering "dubious ownership"` \
         -v "$ROOT":"$ROOT":rw \
         -v "$REPO":"$REPO":ro \
         -v "$REPO2":"$REPO2":ro \
@@ -1024,20 +1024,20 @@ function e2e::readlink() {
         &
     wait_for_sync "${MAXWAIT}"
     assert_link_exists "$ROOT/link"
-    assert_link_basename_eq "$ROOT/link" $(git -C "$REPO" rev-parse HEAD)
+    assert_link_basename_eq "$ROOT/link" "$(git -C "$REPO" rev-parse HEAD)"
 
     # Move HEAD forward
     echo "${FUNCNAME[0]} 2" > "$REPO/file"
     git -C "$REPO" commit -qam "${FUNCNAME[0]} 2"
     wait_for_sync "${MAXWAIT}"
     assert_link_exists "$ROOT/link"
-    assert_link_basename_eq "$ROOT/link" $(git -C "$REPO" rev-parse HEAD)
+    assert_link_basename_eq "$ROOT/link" "$(git -C "$REPO" rev-parse HEAD)"
 
     # Move HEAD backward
     git -C "$REPO" reset -q --hard HEAD^
     wait_for_sync "${MAXWAIT}"
     assert_link_exists "$ROOT/link"
-    assert_link_basename_eq "$ROOT/link" $(git -C "$REPO" rev-parse HEAD)
+    assert_link_basename_eq "$ROOT/link" "$(git -C "$REPO" rev-parse HEAD)"
 }
 
 ##############################################

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -3417,7 +3417,7 @@ function list_tests() {
 }
 
 # Figure out which, if any, tests to run.
-all_tests=($(list_tests))
+mapfile -t all_tests < <(list_tests)
 tests_to_run=()
 
 function print_tests() {

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -2524,23 +2524,23 @@ function e2e::expose_http() {
     done
 
     # check that health endpoint fails
-    if [[ $(curl --write-out %{http_code} --silent --output /dev/null http://localhost:$HTTP_PORT) -ne 503 ]] ; then
-        fail "health endpoint should have failed: $(curl --write-out %{http_code} --silent --output /dev/null http://localhost:$HTTP_PORT)"
+    if [[ $(curl --write-out '%{http_code}' --silent --output /dev/null http://localhost:$HTTP_PORT) -ne 503 ]] ; then
+        fail "health endpoint should have failed: $(curl --write-out '%{http_code}' --silent --output /dev/null http://localhost:$HTTP_PORT)"
     fi
     wait_for_sync "${MAXWAIT}"
 
     # check that health endpoint is alive
-    if [[ $(curl --write-out %{http_code} --silent --output /dev/null http://localhost:$HTTP_PORT) -ne 200 ]] ; then
+    if [[ $(curl --write-out '%{http_code}' --silent --output /dev/null http://localhost:$HTTP_PORT) -ne 200 ]] ; then
         fail "health endpoint failed"
     fi
 
     # check that the metrics endpoint exists
-    if [[ $(curl --write-out %{http_code} --silent --output /dev/null http://localhost:$HTTP_PORT/metrics) -ne 200 ]] ; then
+    if [[ $(curl --write-out '%{http_code}' --silent --output /dev/null http://localhost:$HTTP_PORT/metrics) -ne 200 ]] ; then
         fail "metrics endpoint failed"
     fi
 
     # check that the pprof endpoint exists
-    if [[ $(curl --write-out %{http_code} --silent --output /dev/null http://localhost:$HTTP_PORT/debug/pprof/) -ne 200 ]] ; then
+    if [[ $(curl --write-out '%{http_code}' --silent --output /dev/null http://localhost:$HTTP_PORT/debug/pprof/) -ne 200 ]] ; then
         fail "pprof endpoint failed"
     fi
 }
@@ -2579,7 +2579,7 @@ function e2e::expose_http_after_restart() {
     sleep 2 # wait for first loop to confirm synced
 
     # check that health endpoint is alive
-    if [[ $(curl --write-out %{http_code} --silent --output /dev/null http://localhost:$HTTP_PORT) -ne 200 ]] ; then
+    if [[ $(curl --write-out '%{http_code}' --silent --output /dev/null http://localhost:$HTTP_PORT) -ne 200 ]] ; then
         fail "health endpoint failed"
     fi
     assert_link_exists "$ROOT/link"

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -102,14 +102,14 @@ function assert_file_contains() {
 }
 
 function assert_file_lines_eq() {
-    N=$(cat "$1" | wc -l)
+    N=$(wc -l < "$1")
     if (( "$N" != "$2" )); then
         fail "$1 is not $2 lines: $N"
     fi
 }
 
 function assert_file_lines_ge() {
-    N=$(cat "$1" | wc -l)
+    N=$(wc -l < "$1")
     if (( "$N" < "$2" )); then
         fail "$1 is not at least $2 lines: $N"
     fi


### PR DESCRIPTION
This contribution shellchecks the whole `test_e2e.sh` file. Check individual commits for more details. I've ran `make test` and verified that all tests still pass. Part of #891.