### PR TITLE
Env var handling should prefer old names

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,4 +587,3 @@ HOOKS
     if a hook fails and a new hash is synced during the backoff period, the
     retried hook will fire for the newest hash.
 ```
-

--- a/env_test.go
+++ b/env_test.go
@@ -24,120 +24,187 @@ import (
 
 const (
 	testKey = "KEY"
+	alt1Key = "ALT1"
+	alt2Key = "ALT2"
 )
 
+func setupEnv(val, alt1, alt2 string) {
+	if val != "" {
+		os.Setenv(testKey, val)
+	}
+	if alt1 != "" {
+		os.Setenv(alt1Key, alt1)
+	}
+	if alt2 != "" {
+		os.Setenv(alt2Key, alt2)
+	}
+}
+
+func resetEnv() {
+	os.Unsetenv(testKey)
+	os.Unsetenv(alt1Key)
+	os.Unsetenv(alt2Key)
+}
+
 func TestEnvBool(t *testing.T) {
+	envWarnfOverride = func(format string, args ...any) {
+		t.Logf(format, args...)
+	}
+	defer func() { envWarnfOverride = nil }()
+
 	cases := []struct {
 		value string
+		alt1  string
+		alt2  string
 		def   bool
 		exp   bool
 		err   bool
 	}{
-		{"true", true, true, false},
-		{"true", false, true, false},
-		{"", true, true, false},
-		{"", false, false, false},
-		{"false", true, false, false},
-		{"false", false, false, false},
-		{"", true, true, false},
-		{"", false, false, false},
-		{"no true", false, false, true},
-		{"no false", false, false, true},
+		{"true", "", "", true, true, false},
+		{"true", "", "", false, true, false},
+		{"", "", "", true, true, false},
+		{"", "", "", false, false, false},
+		{"false", "", "", true, false, false},
+		{"false", "", "", false, false, false},
+		{"", "", "", true, true, false},
+		{"", "", "", false, false, false},
+		{"invalid", "", "", false, false, true},
+		{"invalid", "true", "", false, true, false},
+		{"true", "invalid", "", false, false, true},
+		{"invalid", "invalid", "true", false, true, false},
+		{"true", "true", "invalid", false, false, true},
+		{"invalid", "invalid", "invalid", false, false, true},
 	}
 
-	for _, testCase := range cases {
-		os.Setenv(testKey, testCase.value)
-		val, err := envBoolOrError(testCase.def, testKey)
-		if err != nil && !testCase.err {
-			t.Fatalf("%q: unexpected error: %v", testCase.value, err)
+	for i, tc := range cases {
+		resetEnv()
+		setupEnv(tc.value, tc.alt1, tc.alt2)
+		val, err := envBoolOrError(tc.def, testKey, alt1Key, alt2Key)
+		if err != nil && !tc.err {
+			t.Fatalf("%d: %q: unexpected error: %v", i, tc.value, err)
 		}
-		if err == nil && testCase.err {
-			t.Fatalf("%q: unexpected success", testCase.value)
+		if err == nil && tc.err {
+			t.Fatalf("%d: %q: unexpected success", i, tc.value)
 		}
-		if val != testCase.exp {
-			t.Fatalf("%q: expected %v but %v returned", testCase.value, testCase.exp, val)
+		if val != tc.exp {
+			t.Fatalf("%d: expected: %v, got: %v", i, tc.exp, val)
 		}
 	}
 }
 
 func TestEnvString(t *testing.T) {
+	envWarnfOverride = func(format string, args ...any) {
+		t.Logf(format, args...)
+	}
+	defer func() { envWarnfOverride = nil }()
+
 	cases := []struct {
 		value string
+		alt1  string
+		alt2  string
 		def   string
 		exp   string
 	}{
-		{"true", "true", "true"},
-		{"true", "false", "true"},
-		{"", "true", "true"},
-		{"", "false", "false"},
-		{"false", "true", "false"},
-		{"false", "false", "false"},
-		{"", "true", "true"},
-		{"", "false", "false"},
+		{"foo", "", "", "foo", "foo"},
+		{"foo", "", "", "bar", "foo"},
+		{"", "", "", "foo", "foo"},
+		{"", "", "", "bar", "bar"},
+		{"bar", "", "", "foo", "bar"},
+		{"bar", "", "", "bar", "bar"},
+		{"", "", "", "foo", "foo"},
+		{"", "", "", "bar", "bar"},
+		{"foo1", "foo2", "", "bar", "foo2"},
+		{"foo1", "foo2", "foo3", "bar", "foo3"},
 	}
 
-	for _, testCase := range cases {
-		os.Setenv(testKey, testCase.value)
-		val := envString(testCase.def, testKey)
-		if val != testCase.exp {
-			t.Fatalf("%q: expected %v but %v returned", testCase.value, testCase.exp, val)
+	for i, tc := range cases {
+		resetEnv()
+		setupEnv(tc.value, tc.alt1, tc.alt2)
+		val := envString(tc.def, testKey, alt1Key, alt2Key)
+		if val != tc.exp {
+			t.Fatalf("%d: expected: %q, got: %q", i, tc.exp, val)
 		}
 	}
 }
 
 func TestEnvInt(t *testing.T) {
+	envWarnfOverride = func(format string, args ...any) {
+		t.Logf(format, args...)
+	}
+	defer func() { envWarnfOverride = nil }()
+
 	cases := []struct {
 		value string
+		alt1  string
+		alt2  string
 		def   int
 		exp   int
 		err   bool
 	}{
-		{"0", 1, 0, false},
-		{"", 0, 0, false},
-		{"-1", 0, -1, false},
-		{"abcd", 0, 0, true},
-		{"abcd", 0, 0, true},
+		{"0", "", "", 1, 0, false},
+		{"", "", "", 0, 0, false},
+		{"-1", "", "", 0, -1, false},
+		{"invalid", "", "", 0, 0, true},
+		{"invalid", "0", "", 1, 0, false},
+		{"0", "invalid", "", 0, 0, true},
+		{"invalid", "invalid", "0", 1, 0, false},
+		{"0", "0", "invalid", 0, 0, true},
+		{"invalid", "invalid", "invalid", 0, 0, true},
 	}
 
-	for _, testCase := range cases {
-		os.Setenv(testKey, testCase.value)
-		val, err := envIntOrError(testCase.def, testKey)
-		if err != nil && !testCase.err {
-			t.Fatalf("%q: unexpected error: %v", testCase.value, err)
+	for i, tc := range cases {
+		resetEnv()
+		setupEnv(tc.value, tc.alt1, tc.alt2)
+		val, err := envIntOrError(tc.def, testKey, alt1Key, alt2Key)
+		if err != nil && !tc.err {
+			t.Fatalf("%d: %q: unexpected error: %v", i, tc.value, err)
 		}
-		if err == nil && testCase.err {
-			t.Fatalf("%q: unexpected success", testCase.value)
+		if err == nil && tc.err {
+			t.Fatalf("%d: %q: unexpected success", i, tc.value)
 		}
-		if val != testCase.exp {
-			t.Fatalf("%q: expected %v but %v returned", testCase.value, testCase.exp, val)
+		if val != tc.exp {
+			t.Fatalf("%d: expected: %v, got: %v", i, tc.exp, val)
 		}
 	}
 }
 
 func TestEnvFloat(t *testing.T) {
+	envWarnfOverride = func(format string, args ...any) {
+		t.Logf(format, args...)
+	}
+	defer func() { envWarnfOverride = nil }()
+
 	cases := []struct {
 		value string
+		alt1  string
+		alt2  string
 		def   float64
 		exp   float64
 		err   bool
 	}{
-		{"0.5", 0, 0.5, false},
-		{"", 0.5, 0.5, false},
-		{"-0.5", 0, -0.5, false},
-		{"abcd", 0, 0, true},
+		{"0.5", "", "", 0, 0.5, false},
+		{"", "", "", 0.5, 0.5, false},
+		{"-0.5", "", "", 0, -0.5, false},
+		{"invalid", "", "", 0, 0, true},
+		{"invalid", "0.5", "", 0, 0.5, false},
+		{"0.5", "invalid", "", 0, 0, true},
+		{"invalid", "invalid", "0.5", 0, 0.5, false},
+		{"0.5", "0.5", "invalid", 0, 0, true},
+		{"invalid", "invalid", "invalid", 0, 0, true},
 	}
 
-	for _, testCase := range cases {
-		os.Setenv(testKey, testCase.value)
-		val, err := envFloatOrError(testCase.def, testKey)
-		if err != nil && !testCase.err {
-			t.Fatalf("%q: unexpected error: %v", testCase.value, err)
+	for i, tc := range cases {
+		resetEnv()
+		setupEnv(tc.value, tc.alt1, tc.alt2)
+		val, err := envFloatOrError(tc.def, testKey, alt1Key, alt2Key)
+		if err != nil && !tc.err {
+			t.Fatalf("%d: %q: unexpected error: %v", i, tc.value, err)
 		}
-		if err == nil && testCase.err {
-			t.Fatalf("%q: unexpected success", testCase.value)
+		if err == nil && tc.err {
+			t.Fatalf("%d: %q: unexpected success", i, tc.value)
 		}
-		if val != testCase.exp {
-			t.Fatalf("%q: expected %v but %v returned", testCase.value, testCase.exp, val)
+		if val != tc.exp {
+			t.Fatalf("%d: expected: %v, got: %v", i, tc.exp, val)
 		}
 	}
 }
@@ -145,27 +212,35 @@ func TestEnvFloat(t *testing.T) {
 func TestEnvDuration(t *testing.T) {
 	cases := []struct {
 		value string
+		alt1  string
+		alt2  string
 		def   time.Duration
 		exp   time.Duration
 		err   bool
 	}{
-		{"1s", 0, time.Second, false},
-		{"", time.Minute, time.Minute, false},
-		{"1h", 0, time.Hour, false},
-		{"abcd", 0, 0, true},
+		{"1s", "", "", 0, time.Second, false},
+		{"", "", "", time.Minute, time.Minute, false},
+		{"1h", "", "", 0, time.Hour, false},
+		{"invalid", "", "", 0, 0, true},
+		{"invalid", "1s", "", 0, time.Second, false},
+		{"1s", "invalid", "", 0, 0, true},
+		{"invalid", "invalid", "1s", 0, time.Second, false},
+		{"1s", "1s", "invalid", 0, 0, true},
+		{"invalid", "invalid", "invalid", 0, 0, true},
 	}
 
-	for _, testCase := range cases {
-		os.Setenv(testKey, testCase.value)
-		val, err := envDurationOrError(testCase.def, testKey)
-		if err != nil && !testCase.err {
-			t.Fatalf("%q: unexpected error: %v", testCase.value, err)
+	for i, tc := range cases {
+		resetEnv()
+		setupEnv(tc.value, tc.alt1, tc.alt2)
+		val, err := envDurationOrError(tc.def, testKey, alt1Key, alt2Key)
+		if err != nil && !tc.err {
+			t.Fatalf("%d: %q: unexpected error: %v", i, tc.value, err)
 		}
-		if err == nil && testCase.err {
-			t.Fatalf("%q: unexpected success", testCase.value)
+		if err == nil && tc.err {
+			t.Fatalf("%d: %q: unexpected success", i, tc.value)
 		}
-		if val != testCase.exp {
-			t.Fatalf("%q: expected %v but %v returned", testCase.value, testCase.exp, val)
+		if val != tc.exp {
+			t.Fatalf("%d: expected: %v, got: %v", i, tc.exp, val)
 		}
 	}
 }

--- a/v3-to-v4.md
+++ b/v3-to-v4.md
@@ -159,6 +159,11 @@ Most flags can also be configured by environment variables.  In v3 the
 variables all start with `GIT_SYNC_`.  In v4 they all start with `GITSYNC_`,
 though the old names are still accepted for compatibility.
 
+If both an old (`GIT_SYNC_*`) name and a new (`GITSYNC_*`) name are specified,
+the behavior is:
+* v4.0.x - v4.3.x: the new name is used
+* v4.4.x and up: the old name is used
+
 ## Defaults
 
 ### Depth


### PR DESCRIPTION
For back-compat, if we find both an old and new env var for the same flag, prefer the old.  This matters because the docker image sets GITSYNC_ROOT but some users still set GIT_SYNC_ROOT.

Fixes #928 