### PR TITLE
fix: Correct typo in code comment

### DIFF
--- a/vendor/github.com/prometheus/client_golang/prometheus/wrap.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/wrap.go
@@ -207,7 +207,7 @@ func wrapDesc(desc *Desc, prefix string, labels Labels) *Desc {
 	}
 	// NewDesc will do remaining validations.
 	newDesc := NewDesc(prefix+desc.fqName, desc.help, desc.variableLabels, constLabels)
-	// Propagate errors if there was any. This will override any errer
+	// Propagate errors if there was any. This will override any error
 	// created by NewDesc above, i.e. earlier errors get precedence.
 	if desc.err != nil {
 		newDesc.err = desc.err

--- a/vendor/github.com/prometheus/common/model/labels.go
+++ b/vendor/github.com/prometheus/common/model/labels.go
@@ -138,7 +138,7 @@ func (ln *LabelName) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// LabelNames is a sortable LabelName slice. In implements sort.Interface.
+// LabelNames is a sortable LabelName slice. It implements sort.Interface.
 type LabelNames []LabelName
 
 func (l LabelNames) Len() int {

--- a/vendor/github.com/spf13/pflag/count.go
+++ b/vendor/github.com/spf13/pflag/count.go
@@ -85,7 +85,7 @@ func (f *FlagSet) CountP(name, shorthand string, usage string) *int {
 
 // Count defines a count flag with specified name, default value, and usage string.
 // The return value is the address of an int variable that stores the value of the flag.
-// A count flag will add 1 to its value evey time it is found on the command line
+// A count flag will add 1 to its value every time it is found on the command line
 func Count(name string, usage string) *int {
 	return CommandLine.CountP(name, "", usage)
 }


### PR DESCRIPTION
Minor typo fixes in comments.

Changed files:
- vendor/github.com/prometheus/client_golang/prometheus/wrap.go
- vendor/github.com/prometheus/common/model/labels.go
- vendor/github.com/spf13/pflag/count.go


This change does not include functional changes.