### PR TITLE
fix: gracefully handle nil err in Logger

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -57,8 +57,10 @@ func (l *Logger) Error(err error, msg string, kvList ...interface{}) {
 		Args map[string]interface{}
 	}{
 		Msg:  msg,
-		Err:  err.Error(),
 		Args: map[string]interface{}{},
+	}
+	if err != nil {
+		payload.Err = err.Error()
 	}
 	if len(kvList)%2 != 0 {
 		kvList = append(kvList, "<no-value>")


### PR DESCRIPTION
This handles the case where a null error is passed into the Logger without causing a null pointer dereference / segfault. There are currently a couple places that invoke this function with a nil error and were resulting in a segfault.