### PR TITLE
add --hooks-async and --hooks-before-symlink flags

### DIFF
--- a/_test_tools/exechook_command_with_sleep.sh
+++ b/_test_tools/exechook_command_with_sleep.sh
@@ -19,4 +19,6 @@
 
 sleep 3
 cat file > exechook
+cat exechook
+if [[ "$(pwd)" != "$(pwd -P)" ]]; then echo "true" > delaycheck; fi
 echo "ENVKEY=$ENVKEY" > exechook-env

--- a/main.go
+++ b/main.go
@@ -207,7 +207,8 @@ func main() {
 	flGroupWrite := pflag.Bool("group-write",
 		envBool(false, "GITSYNC_GROUP_WRITE", "GIT_SYNC_GROUP_WRITE"),
 		"ensure that all data (repo, worktrees, etc.) is group writable")
-	flStaleWorktreeTimeout := pflag.Duration("stale-worktree-timeout", envDuration(0, "GITSYNC_STALE_WORKTREE_TIMEOUT"),
+	flStaleWorktreeTimeout := pflag.Duration("stale-worktree-timeout",
+		envDuration(0, "GITSYNC_STALE_WORKTREE_TIMEOUT"),
 		"how long to retain non-current worktrees")
 
 	flExechookCommand := pflag.String("exechook-command",
@@ -235,6 +236,10 @@ func main() {
 	flWebhookBackoff := pflag.Duration("webhook-backoff",
 		envDuration(3*time.Second, "GITSYNC_WEBHOOK_BACKOFF", "GIT_SYNC_WEBHOOK_BACKOFF"),
 		"the time to wait before retrying a failed webhook")
+
+	flHooksAsync := pflag.Bool("hooks-async",
+		envBool(true, "GITSYNC_HOOKS_ASYNC", "GIT_SYNC_HOOKS_ASYNC"),
+		"run hooks asynchronously")
 
 	flUsername := pflag.String("username",
 		envString("", "GITSYNC_USERNAME", "GIT_SYNC_USERNAME"),
@@ -844,6 +849,7 @@ func main() {
 			hook.NewHookData(),
 			log,
 			*flOneTime,
+			*flHooksAsync,
 		)
 		go webhookRunner.Run(context.Background())
 	}
@@ -868,6 +874,7 @@ func main() {
 			hook.NewHookData(),
 			log,
 			*flOneTime,
+			*flHooksAsync,
 		)
 		go exechookRunner.Run(context.Background())
 	}

--- a/main.go
+++ b/main.go
@@ -2574,6 +2574,13 @@ OPTIONS
     -?, -h, --help
             Print help text and exit.
 
+	--hooks-async, $GITSYNC_HOOKS_ASYNC
+			Whether to run the --exechook-command asynchronously.
+
+	--hooks-before-symlink, $GITSYNC_HOOKS_BEFORE_SYMLINK
+			Whether to run the --exechook-command before updating the symlink. Use in combination with --hooks-async set
+			to false if you need the hook to finish before the symlink is updated. 
+
     --http-bind <string>, $GITSYNC_HTTP_BIND
             The bind address (including port) for git-sync's HTTP endpoint.
             The '/' URL of this endpoint is suitable for Kubernetes startup and

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -3846,7 +3846,8 @@ for t; do
         fi
         remove_containers || true
         run=$((run+1))
-    done    if [[ "$test_ret" != 0 ]]; then
+    done
+    if [[ "$test_ret" != 0 ]]; then
         final_ret=1
         failures+=("$t  (log: ${log}.*)")
     fi

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -2406,7 +2406,7 @@ function e2e::exechook_fail_retry() {
         --exechook-command="/$EXECHOOK_COMMAND_FAIL" \
         --exechook-backoff=1s \
         &
-    sleep 3 # give it time to retry
+    sleep 4 # give it time to retry
 
     # Check that exechook was called
     assert_file_lines_ge "$RUNLOG" 2
@@ -2484,6 +2484,29 @@ function e2e::exechook_startup_after_crash() {
     assert_file_eq "$ROOT/link/exechook" "${FUNCNAME[0]}"
     assert_file_eq "$ROOT/link/exechook-env" "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
     assert_file_lines_eq "$RUNLOG" 1
+}
+
+##############################################
+# Test exechook-success with --hooks-async=false
+##############################################
+function e2e::exechook_success_hooks_non_async() {
+    cat /dev/null > "$RUNLOG"
+
+    GIT_SYNC \
+        --hooks-async=false \
+        --period=100ms \
+        --repo="file://$REPO" \
+        --root="$ROOT" \
+        --link="link" \
+        --exechook-command="/$EXECHOOK_COMMAND_SLEEPY" \
+        &
+    sleep 5 # give it time to run
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/exechook"
+    assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]}"
+    assert_file_eq "$ROOT/link/exechook" "${FUNCNAME[0]}"
+    assert_file_eq "$ROOT/link/exechook-env" "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
 }
 
 ##############################################
@@ -3797,8 +3820,7 @@ for t; do
         fi
         remove_containers || true
         run=$((run+1))
-    done
-    if [[ "$test_ret" != 0 ]]; then
+    done    if [[ "$test_ret" != 0 ]]; then
         final_ret=1
         failures+=("$t  (log: ${log}.*)")
     fi

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -96,7 +96,7 @@ function assert_file_eq() {
     if [[ $(cat "$1") == "$2" ]]; then
         return
     fi
-    fail "$1 does not contain '$2': $(cat "$1")"
+    fail "$1 does not equal '$2': $(cat "$1")"
 }
 
 function assert_file_contains() {
@@ -2507,6 +2507,32 @@ function e2e::exechook_success_hooks_non_async() {
     assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]}"
     assert_file_eq "$ROOT/link/exechook" "${FUNCNAME[0]}"
     assert_file_eq "$ROOT/link/exechook-env" "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
+}
+
+##############################################
+# Test exechook-success with --hooks-async=false and --hooks-before-symlink
+##############################################
+function e2e::exechook_success_hooks_before_symlink_non_async() {
+    cat /dev/null > "$RUNLOG"
+
+    GIT_SYNC \
+        --hooks-async=false \
+        --hooks-before-symlink \
+        --period=100ms \
+        --repo="file://$REPO" \
+        --root="$ROOT" \
+        --link="link" \
+        --exechook-command="/$EXECHOOK_COMMAND_SLEEPY" \
+        --exechook-backoff=1s \
+        &
+    sleep 5 # give it time to run
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/exechook"
+    assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]}"
+    assert_file_eq "$ROOT/link/exechook" "${FUNCNAME[0]}"
+    assert_file_eq "$ROOT/link/exechook-env" "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
+    assert_file_absent "$ROOT/link/delaycheck"
 }
 
 ##############################################


### PR DESCRIPTION
https://github.com/kubernetes/git-sync/issues/937

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds flags for --hooks-async and --hooks-before-symlink
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #937

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- adds --hooks-async: Whether to run the exechook and webhook commands in an async or sync way. 
- adds --hooks-before-symlink: When to run the --exechook-command.  If true, will run the exechook or webhook commands before the symlink is updated. 
            ExecHook is asynchronous, so setting this will
            not block the sync process. If you need the hook to run to completion
            before the symlink is updated, you should use this in conjunction with --hooks-async=false.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
