### PR TITLE
Improve local builds with another buildx builder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,29 @@ We'd love to accept your patches, but before we can do that, you must sign the C
 ## Contributing A Patch
 
 1. Submit an issue describing your proposed change.
-1. If your proposal is accepted, and you haven't already done so, sign the Contributor License Agreement (see details above).
-1. Fork the repo, develop and test your code changes.  Don't forget tests!
-1. Submit a pull request.
+2. If your proposal is accepted, and you haven't already done so, sign the Contributor License Agreement (see details above).
+3. Fork the repo, develop and test your code changes.  Don't forget tests!
+4. Submit a pull request.
+
+## Building container images with *buildx* locally on your computer
+
+First, please read the following article:
+[Building Multi-Architecture Docker Images With Buildx](https://medium.com/@artur.klauser/building-multi-architecture-docker-images-with-buildx-27d80f7e2408).
+
+By default the `Makefile` creates a *buildx* builder dedicated to `git-sync` with a container driver. But it won't work out-of-the-box
+if you use private container images registries and *pull* private dependencies, with authentication. You can adapt the *buildx* builder
+for a local build.
+
+For example, if you've already got a `default` *buildx* builder with a docker driver (with access to the host engine) you can try
+to run a build with the following call to `make`:
+
+```sh
+docker login $YOUR_PRIVATE_REGISTRY
+docker pull $BUILD_IMAGE_IN_PRIVATE_REGISTRY
+docker pull $BASEIMAGE_IN_PRIVATE_REGISTRY
+make all-container \
+       BUILDX_BUILDER_SKIP_CREATION=skip \
+       BUILDX_BUILDER_NAME=default \
+       BUILD_IMAGE=$BUILD_IMAGE_IN_PRIVATE_REGISTRY \
+       BASEIMAGE=$BASEIMAGE_IN_PRIVATE_REGISTRY
+```

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ DBG ?=
 HTTP_PROXY ?=
 HTTPS_PROXY ?=
 
+# Allow some buildx adaptation for local builds
+BUILDX_BUILDER_NAME := git-sync
+BUILDX_BUILDER_SKIP_CREATION ?=
+
 ###
 ### These variables should not need tweaking.
 ###
@@ -177,7 +181,7 @@ container: .container-$(DOTFILE_IMAGE) container-name
 	FORCE=0;                                                     \
 	if [ -z "$(ALLOW_STALE_APT)" ]; then FORCE=$$(date +%s); fi; \
 	docker buildx build                                          \
-	    --builder git-sync                                       \
+	    --builder "$(BUILDX_BUILDER_NAME)"                       \
 	    --build-arg FORCE_REBUILD="$$FORCE"                      \
 	    --build-arg HASH_LICENSES="$$HASH_LICENSES"              \
 	    --build-arg HASH_BINARY="$$HASH_BINARY"                  \
@@ -262,7 +266,7 @@ test-tools: $(foreach tool, $(TEST_TOOLS), .container-test_tool.$(tool))
 # this.  See https://medium.com/@artur.klauser/building-multi-architecture-docker-images-with-buildx-27d80f7e2408
 # for great context.
 .buildx-initialized:
-	docker buildx create --name git-sync --node git-sync-0 >/dev/null
+	if [ -z "$(BUILDX_BUILDER_SKIP_CREATION)" ]; then docker buildx create --name "$(BUILDX_BUILDER_NAME)" --node git-sync-0 >/dev/null; fi
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes >/dev/null
 	date > $@
 


### PR DESCRIPTION
Introduces to new parameters in the Makefile:
- BUILDX_BUILDER_NAME, allowing to select the builder
- BUILDX_BUILDER_SKIP_CREATION, to skip the builder creation when the builder already exists and is not managed by the Makefile

NOTE : I propose this in parallel of the feature request [#970](https://github.com/kubernetes/git-sync/issues/970) as I had to make some adaptations locally to be able to build the project, and I think they could be used by others.