### PR TITLE
Improve running end-to-end tests locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-/bin
-/.go
-/.push-*
+/.buildx-initialized
 /.container-*
 /.dockerfile-*
-/.buildx-initialized
+/.go
+/.idea
 /.licenses
+/.push-*
+/bin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,59 @@ make all-container \
        BUILD_IMAGE=$BUILD_IMAGE_IN_PRIVATE_REGISTRY \
        BASEIMAGE=$BASEIMAGE_IN_PRIVATE_REGISTRY
 ```
+
+## Running end-to-end tests using fully-qualified base images
+
+By default the `_test_tools/*/Dockerfile` images used by the end-to-end tests are built in the `Makefile`'s `.container-test_tool.%` goals
+using an unqualified `alpine` image.
+
+In order to pull the `alpine` image from a private registry and/or with a fully-qualified name, and run the tests, you can
+use for example:
+
+```sh
+docker login $YOUR_PRIVATE_REGISTRY
+ALPINE_REGISTRY_PREFIX=$YOUR_PRIVATE_REGISTRY/$YOUR_ALPINE_NAMESPACE_PREFIX/ # Please note the final '/'
+docker pull ${ALPINE_REGISTRY_PREFIX}alpine
+make test ALPINE_REGISTRY_PREFIX=$ALPINE_REGISTRY_PREFIX
+```
+
+## Running end-to-end tests locally with docker configured behind a proxy
+
+If you are using proxy configurations in your `~/.docker/config` file, you must add the `docker0` subnet (created by the
+*bridge* network) as an exception in order for the containers executed by the tests to be able to call each other. 
+
+For example to get the subnets associated with the *bridge* network in a default Docker configuration you can run:
+
+```bash
+docker network ls # you can verify that a network called bridge is present
+docker network inspect bridge --format '{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}'
+```
+
+If for example your *bridge* subnet is `172.16.0.0/12`, then you'd want your `~/.docker/config.json` to look like this:
+
+```json
+{
+        "proxies": {
+                "default": {
+                        "httpProxy": "...",
+                        "httpsProxy": "...",
+                        "noProxy": "...,172.16.0.0/12"
+                }
+        }
+}
+```
+
+And you'd want to run the tests like this:
+
+```bash
+make test HTTP_PROXY="..." HTTPS_PROXY="..." NO_PROXY"...,172.16.0.0/12"
+```
+
+Or manually:
+
+```bash
+export HTTP_PROXY="..."
+export HTTPS_PROXY="..."
+export NO_PROXY"...,172.16.0.0/12"
+VERBOSE=1 ./test_e2e.sh
+```

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,14 @@ DBG ?=
 # These are passed to docker when building and testing.
 HTTP_PROXY ?=
 HTTPS_PROXY ?=
+NO_PROXY ?=
 
 # Allow some buildx adaptation for local builds
 BUILDX_BUILDER_NAME := git-sync
 BUILDX_BUILDER_SKIP_CREATION ?=
+
+# Allow alpine to be pulled from a private registry when building the end-to-end tests images
+ALPINE_REGISTRY_PREFIX ?=
 
 ###
 ### These variables should not need tweaking.
@@ -134,6 +138,7 @@ $(OUTBIN): .go/$(OUTBIN).stamp
 	    -v $$(pwd)/.go/cache:/.cache                           \
 	    --env HTTP_PROXY=$(HTTP_PROXY)                         \
 	    --env HTTPS_PROXY=$(HTTPS_PROXY)                       \
+	    --env NO_PROXY=$(NO_PROXY)                             \
 	    $(BUILD_IMAGE)                                         \
 	    /bin/sh -c "                                           \
 	        ARCH=$(ARCH)                                       \
@@ -190,6 +195,7 @@ container: .container-$(DOTFILE_IMAGE) container-name
 	    --platform "$(OS)/$(ARCH)"                               \
 	    --build-arg HTTP_PROXY=$(HTTP_PROXY)                     \
 	    --build-arg HTTPS_PROXY=$(HTTPS_PROXY)                   \
+	    --build-arg NO_PROXY=$(NO_PROXY)                         \
 	    -t $(IMAGE):$(OS_ARCH_TAG)                               \
 	    -f .dockerfile-$(OS)_$(ARCH)                             \
 	    .
@@ -248,17 +254,27 @@ test: $(BUILD_DIRS)
 	    -v $$(pwd)/.go/cache:/.cache                           \
 	    --env HTTP_PROXY=$(HTTP_PROXY)                         \
 	    --env HTTPS_PROXY=$(HTTPS_PROXY)                       \
+	    --env NO_PROXY=$(NO_PROXY)                             \
 	    $(BUILD_IMAGE)                                         \
 	    /bin/sh -c "                                           \
 	        ./build/test.sh ./...                              \
 	    "
+	@if [ -n "$(HTTP_PROXY)" ]; then \
+		export HTTP_PROXY="$(HTTP_PROXY)"; \
+	fi
+	@if [ -n "$(HTTPS_PROXY)" ]; then \
+		export HTTPS_PROXY="$(HTTPS_PROXY)"; \
+	fi
+	@if [ -n "$(NO_PROXY)" ]; then \
+		export NO_PROXY="$(NO_PROXY)"; \
+	fi
 	VERBOSE=1 ./test_e2e.sh
 
 TEST_TOOLS := $(shell find _test_tools/* -type d -printf "%f ")
 test-tools: $(foreach tool, $(TEST_TOOLS), .container-test_tool.$(tool))
 
 .container-test_tool.%: _test_tools/% _test_tools/%/*
-	docker build -t $(REGISTRY)/test/$$(basename $<) $<
+	docker build --build-arg ALPINE_REGISTRY_PREFIX="$(ALPINE_REGISTRY_PREFIX)" -t $(REGISTRY)/test/$$(basename $<) $<
 	docker images -q $(REGISTRY)/test/$$(basename $<) > $@
 
 # Help set up multi-arch build tools.  This assumes you have the tools

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ BUILDX_BUILDER_SKIP_CREATION ?=
 # Allow alpine to be pulled from a private registry when building the end-to-end tests images
 ALPINE_REGISTRY_PREFIX ?=
 
+# By default all end-to-end tests are executed, but this allows for a manual selection
+LIST_OF_E2E_TESTS ?=
+
 ###
 ### These variables should not need tweaking.
 ###
@@ -268,7 +271,7 @@ test: $(BUILD_DIRS)
 	@if [ -n "$(NO_PROXY)" ]; then \
 		export NO_PROXY="$(NO_PROXY)"; \
 	fi
-	VERBOSE=1 ./test_e2e.sh
+	VERBOSE=1 ./test_e2e.sh $(LIST_OF_E2E_TESTS)
 
 TEST_TOOLS := $(shell find _test_tools/* -type d -printf "%f ")
 test-tools: $(foreach tool, $(TEST_TOOLS), .container-test_tool.$(tool))

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,10 @@ BUILDX_BUILDER_SKIP_CREATION ?=
 # Allow alpine to be pulled from a private registry when building the end-to-end tests images
 ALPINE_REGISTRY_PREFIX ?=
 
-# By default all end-to-end tests are executed, but this allows for a manual selection
+# By default all end-to-end tests are executed, but this allows for a manual selection.
+# NOTE: Each item in this list will be used as a regex to run functions of the form 'e2e::${MATCHING_TEST_NAME}'
+#       in the test_e2e.sh script. For example using 'auth' will include all authentication end-to-end tests.
+#       If multiple items match a same test, it will be executed only once.
 LIST_OF_E2E_TESTS ?=
 
 ###
@@ -246,6 +249,8 @@ release:
 version:
 	echo $(VERSION)
 
+# Run the 'test' goal in a single shell
+test: .SHELLFLAGS = -c
 test: $(BUILD_DIRS)
 	docker run                                                 \
 	    -i                                                     \

--- a/_test_tools/httpd/Dockerfile
+++ b/_test_tools/httpd/Dockerfile
@@ -14,7 +14,8 @@
 
 # Stolen from https://github.com/linuxkit/linuxkit/tree/master/pkg/sshd/
 
-FROM alpine AS base
+ARG ALPINE_REGISTRY_PREFIX=""
+FROM ${ALPINE_REGISTRY_PREFIX}alpine AS base
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/_test_tools/ncsvr/Dockerfile
+++ b/_test_tools/ncsvr/Dockerfile
@@ -14,7 +14,8 @@
 
 # Stolen from https://github.com/linuxkit/linuxkit/tree/master/pkg/sshd/
 
-FROM alpine AS base
+ARG ALPINE_REGISTRY_PREFIX=""
+FROM ${ALPINE_REGISTRY_PREFIX}alpine AS base
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/_test_tools/sshd/Dockerfile
+++ b/_test_tools/sshd/Dockerfile
@@ -14,7 +14,8 @@
 
 # Stolen from https://github.com/linuxkit/linuxkit/tree/master/pkg/sshd/
 
-FROM alpine AS base
+ARG ALPINE_REGISTRY_PREFIX=""
+FROM ${ALPINE_REGISTRY_PREFIX}alpine AS base
 
 RUN mkdir -p /out/etc/apk && cp -r /etc/apk/* /out/etc/apk/
 RUN apk add --no-cache --initdb -p /out \

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -18,6 +18,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# If the Makefile and/or the user do set up the upper-case flavor of a proxy variable,
+# then let us also set up the lower-case flavor that is used by tools like the git CLI.
+[ -n "${HTTP_PROXY:-}"  ] && export http_proxy="$HTTP_PROXY"
+[ -n "${HTTPS_PROXY:-}" ] && export https_proxy="$HTTPS_PROXY"
+[ -n "${NO_PROXY:-}"    ] && export no_proxy="$NO_PROXY"
+
 # shellcheck disable=SC2120
 function caller() {
     local stack_skip=${1:-0}

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -3451,7 +3451,7 @@ function e2e::touch_file_abs_path() {
 function e2e::github_https() {
     GIT_SYNC \
         --one-time \
-        --repo="https://github.com/kubernetes/git-sync" \
+        --repo="${GIT_SYNC_REPOSITORY_URL:-https://github.com/kubernetes/git-sync}" \
         --root="$ROOT" \
         --link="link"
     assert_file_exists "$ROOT/link/LICENSE"

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -3676,9 +3676,6 @@ if [[ "$#" == 0 ]]; then
 fi
 
 # Build it
-# NOTE: If you want to run the end-to-end tests locally and you need specific Makefile arguments
-#       you might want to run `make test` once first with those arguments, in order to pre-build this image.
-#       Otherwise this call to the Makefile will made without customization.
 $build_container && make container REGISTRY=e2e VERSION="${E2E_TAG}" ALLOW_STALE_APT=1
 make test-tools REGISTRY=e2e
 

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -3449,9 +3449,11 @@ function e2e::touch_file_abs_path() {
 # Test github HTTPS
 ##############################################
 function e2e::github_https() {
+    local default_repo="https://github.com/kubernetes/git-sync"
+    local repo="${REMOTE_TEST_REPO_URL:-$default_repo}"
     GIT_SYNC \
         --one-time \
-        --repo="${GIT_SYNC_REPOSITORY_URL:-https://github.com/kubernetes/git-sync}" \
+        --repo="$repo" \
         --root="$ROOT" \
         --link="link"
     assert_file_exists "$ROOT/link/LICENSE"

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -3676,6 +3676,9 @@ if [[ "$#" == 0 ]]; then
 fi
 
 # Build it
+# NOTE: If you want to run the end-to-end tests locally and you need specific Makefile arguments
+#       you might want to run `make test` once first with those arguments, in order to pre-build this image.
+#       Otherwise this call to the Makefile will made without customization.
 $build_container && make container REGISTRY=e2e VERSION="${E2E_TAG}" ALLOW_STALE_APT=1
 make test-tools REGISTRY=e2e
 


### PR DESCRIPTION
* Allow users to run end-to-end tests with a fully-qualified and/or private `alpine` image
* Allow users to run end-to-end tests behind a proxy
* Introduces a new `NO_PROXY` parameter in the `Makefile` that is propagated alongside `HTTP_PROXY` and `HTTPS_PROXY`
* Introduces a new `LIST_OF_E2E_TESTS` parameter in the `Makefile` that drives the names of the tests passed to `./test_e2e.sh` to run a selection of tests, running all tests by default
* Allow users to override the git-sync repository URL used by end-to-end tests, by exporting `GIT_SYNC_REPOSITORY_URL` in their environment, in order to use a mirror if need be
* Sort `.gitgnore` for convenience for future diffs
* Add `.idea/` to `.gitignore`

NOTE : I propose this in parallel of the feature request [#970](https://github.com/kubernetes/git-sync/issues/970) as I had to make some adaptations locally to be able to run the end-to-end tests and I think they could be used by others. It completes the [PR #971](https://github.com/kubernetes/git-sync/pull/971) that has already been merged.

/kind feature