### PR TITLE
Add tar and gzip to the git-sync image

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -56,12 +56,14 @@ COPY stage_binaries.sh /
 RUN /stage_binaries.sh -o {ARG_STAGING} \
 	-p base-files \
 	-p bash \
-	-p coreutils \
-	-p git \
-	-p openssh-client \
 	-p ca-certificates \
+	-p coreutils \
 	-p curl \
+	-p git \
+	-p gzip \
+	-p openssh-client \
 	-p socat \
+	-p tar \
 	-b /bin/grep \
 	-b /bin/sed \
 	-f /etc/debian_version \

--- a/_test_tools/exechook_command_git_archive.sh
+++ b/_test_tools/exechook_command_git_archive.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Use for e2e test of --exechook-command.
+# This option takes no command arguments, so requires a wrapper script.
+
+git archive --format tar.gz --output archive.tgz HEAD

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -122,6 +122,12 @@ function assert_file_lines_ge() {
     fi
 }
 
+function assert_tgz_archive() {
+    if ! tar tzf "$1"; then
+        fail "failed to list tgz archive content in $1"
+    fi
+}
+
 function assert_metric_eq() {
     local val
     val="$(curl --silent "http://localhost:$HTTP_PORT/metrics" \
@@ -317,6 +323,7 @@ EXECHOOK_COMMAND="$TEST_TOOLS/exechook_command.sh"
 EXECHOOK_COMMAND_FAIL="$TEST_TOOLS/exechook_command_fail.sh"
 EXECHOOK_COMMAND_SLEEPY="$TEST_TOOLS/exechook_command_with_sleep.sh"
 EXECHOOK_COMMAND_FAIL_SLEEPY="$TEST_TOOLS/exechook_command_fail_with_sleep.sh"
+EXECHOOK_COMMAND_GIT_ARCHIVE="$TEST_TOOLS/exechook_command_git_archive.sh"
 EXECHOOK_ENVKEY=ENVKEY
 EXECHOOK_ENVVAL=envval
 RUNLOG="$DIR/runlog"
@@ -3600,6 +3607,20 @@ function e2e::gc_off() {
     assert_link_exists "$ROOT/link"
     assert_file_exists "$ROOT/link/file"
     assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]}"
+}
+
+##############################################
+# Test git-archive using tar and gzip
+##############################################
+function e2e::exechook_git_archive() {
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --root="$ROOT" \
+        --link="link" \
+        --exechook-command="/$EXECHOOK_COMMAND_GIT_ARCHIVE"
+    assert_file_exists "$ROOT/link/archive.tgz"
+    assert_tgz_archive "$ROOT/link/archive.tgz"
 }
 
 #


### PR DESCRIPTION
Closes #970

/kind feature
Availibity of tar and gzip in the docker image to use with git-archive

* Adding the packages `tar` and `gzip` during the staging phase in the image
* Adding an end-to-end test, testing that a post-sync hook that runs `git-archive` can use the format `tgz`
* Sorting the inputs of `/stage_binaries.sh` in the Dockerfile for convenience for future diffs