### PR TITLE
Automatically re-read password-file during each sync cycle

### DIFF
--- a/main.go
+++ b/main.go
@@ -245,6 +245,9 @@ func main() {
 	flPasswordFile := pflag.String("password-file",
 		envString("", "GITSYNC_PASSWORD_FILE", "GIT_SYNC_PASSWORD_FILE"),
 		"the file from which the password or personal access token for git auth will be sourced")
+	flPasswordFileReload := pflag.Bool("password-file-reload",
+		envBool(false, "GITSYNC_PASSWORD_FILE_RELOAD"),
+		"reload the password from --password-file on each sync cycle (useful when password is rotated by an external system like Vault Dynamic Engine)")
 	flCredentials := pflagCredentialSlice("credential", envString("", "GITSYNC_CREDENTIAL"), "one or more credentials (see --man for details) available for authentication")
 
 	flSSHKeyFiles := pflag.StringArray("ssh-key-file",
@@ -883,7 +886,20 @@ func main() {
 	refreshCreds := func(ctx context.Context) error {
 		// These should all be mutually-exclusive configs.
 		for _, cred := range *flCredentials {
-			if err := git.StoreCredentials(ctx, cred.URL, cred.Username, cred.Password); err != nil {
+			password := cred.Password
+
+			// If reload flag is set and this credential has a password file,
+			// re-read it from disk to pick up token rotation (e.g. from Vault)
+			if *flPasswordFileReload && cred.PasswordFile != "" {
+				passwordFileBytes, err := os.ReadFile(cred.PasswordFile)
+				if err != nil {
+					return fmt.Errorf("can't reload password file %q: %w", cred.PasswordFile, err)
+				}
+				password = string(passwordFileBytes)
+				git.log.V(3).Info("reloaded password from file", "file", cred.PasswordFile)
+			}
+
+			if err := git.StoreCredentials(ctx, cred.URL, cred.Username, password); err != nil {
 				return err
 			}
 		}
@@ -2585,6 +2601,15 @@ OPTIONS
             The file from which the password or personal access token (see
             github docs) to use for git authentication (see --username) will be
             read.  See also $GITSYNC_PASSWORD.
+
+    --password-file-reload, $GITSYNC_PASSWORD_FILE_RELOAD
+            Reload the password from --password-file on each sync cycle.  This
+            is useful when using dynamic credentials that are rotated by an
+            external system (e.g. Vault's dynamic GitHub secrets engine).
+            Without this flag, the password file is read once at startup and
+            cached in memory.  With this flag enabled, the file will be re-read
+            before each sync attempt, allowing git-sync to pick up token
+            rotations.  If not specified, this defaults to false.
 
     --period <duration>, $GITSYNC_PERIOD
             How long to wait between sync attempts.  This must be at least

--- a/main.go
+++ b/main.go
@@ -873,7 +873,7 @@ func main() {
 			password := cred.Password
 
 			// If this credential has a password file, re-read it from disk
-			// to pick up token rotation (e.g. from Vault)
+			// to pick up token rotation
 			if cred.PasswordFile != "" {
 				passwordFileBytes, err := os.ReadFile(cred.PasswordFile)
 				if err != nil {

--- a/main.go
+++ b/main.go
@@ -247,7 +247,7 @@ func main() {
 		"the file from which the password or personal access token for git auth will be sourced")
 	flPasswordFileReload := pflag.Bool("password-file-reload",
 		envBool(false, "GITSYNC_PASSWORD_FILE_RELOAD"),
-		"reload the password from --password-file on each sync cycle (useful when password is rotated by an external system like Vault Dynamic Engine)")
+		"reload the password from --password-file on each sync cycle, useful when password is rotated by an external system")
 	flCredentials := pflagCredentialSlice("credential", envString("", "GITSYNC_CREDENTIAL"), "one or more credentials (see --man for details) available for authentication")
 
 	flSSHKeyFiles := pflag.StringArray("ssh-key-file",

--- a/main.go
+++ b/main.go
@@ -2586,7 +2586,7 @@ OPTIONS
             github docs) to use for git authentication (see --username) will be
             read.  The file is re-read before each sync attempt, allowing
             git-sync to pick up token rotations automatically (e.g. when 
-						credentials are dynamically rotated by external systems).
+			credentials are dynamically rotated by external systems).
             See also $GITSYNC_PASSWORD.
 
     --period <duration>, $GITSYNC_PERIOD

--- a/main.go
+++ b/main.go
@@ -2586,7 +2586,7 @@ OPTIONS
             github docs) to use for git authentication (see --username) will be
             read.  The file is re-read before each sync attempt, allowing
             git-sync to pick up token rotations automatically (e.g. when using
-            dynamic credentials from Vault's dynamic GitHub secrets engine).
+            dynamic credentials from an external secrets system).
             See also $GITSYNC_PASSWORD.
 
     --period <duration>, $GITSYNC_PERIOD

--- a/main.go
+++ b/main.go
@@ -2585,8 +2585,8 @@ OPTIONS
             The file from which the password or personal access token (see
             github docs) to use for git authentication (see --username) will be
             read.  The file is re-read before each sync attempt, allowing
-            git-sync to pick up token rotations automatically (e.g. when 
-			credentials are dynamically rotated by external systems).
+            git-sync to pick up token rotations automatically (e.g. when using
+            dynamic credentials from Vault's dynamic GitHub secrets engine).
             See also $GITSYNC_PASSWORD.
 
     --period <duration>, $GITSYNC_PERIOD

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -2025,7 +2025,7 @@ function e2e::auth_http_password_file() {
 ##############################################
 # Test password-file reload on each sync
 ##############################################
-function e2e::auth_http_password_file_reload() {
+function e2e::auth_password_file_reload() {
     # Run a git-over-HTTP server.
     local ctr
     ctr=$(docker_run \
@@ -2048,6 +2048,7 @@ function e2e::auth_http_password_file_reload() {
         --link="link" \
         --username="testuser" \
         --password-file="$WORK/password-file" \
+        --max-failures=100 \
         &
     wait_for_sync "${MAXWAIT}"
     assert_link_exists "$ROOT/link"

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -2023,6 +2023,63 @@ function e2e::auth_http_password_file() {
 }
 
 ##############################################
+# Test password-file reload on each sync
+##############################################
+function e2e::auth_http_password_file_reload() {
+    # Run a git-over-HTTP server.
+    local ctr
+    ctr=$(docker_run \
+        -v "$REPO":/git/repo:ro \
+        e2e/test/httpd)
+    local ip
+    ip=$(docker_ip "$ctr")
+
+    # Create a password file with the correct password.
+    echo -n "testpass" > "$WORK/password-file"
+
+    # First sync
+    echo "${FUNCNAME[0]} 1" > "$REPO/file"
+    git -C "$REPO" commit -qam "${FUNCNAME[0]} 1"
+
+    GIT_SYNC \
+        --period=1s \
+        --repo="http://$ip/repo" \
+        --root="$ROOT" \
+        --link="link" \
+        --username="testuser" \
+        --password-file="$WORK/password-file" \
+        &
+    wait_for_sync "${MAXWAIT}"
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]} 1"
+
+    # Change password file to wrong password
+    echo -n "wrong" > "$WORK/password-file.tmp"
+    mv "$WORK/password-file.tmp" "$WORK/password-file"
+
+    # Commit a change to the repo
+    echo "${FUNCNAME[0]} 2" > "$REPO/file"
+    git -C "$REPO" commit -qam "${FUNCNAME[0]} 2"
+
+    # Wait a bit and verify sync did NOT happen (still has old content)
+    sleep 3
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]} 1"
+
+    # Change password file back to correct password
+    echo -n "testpass" > "$WORK/password-file.tmp"
+    mv "$WORK/password-file.tmp" "$WORK/password-file"
+
+    # Verify sync now picks up the new change
+    wait_for_sync "${MAXWAIT}"
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]} 2"
+}
+
+##############################################
 # Test SSH (user@host:path syntax)
 ##############################################
 function e2e::auth_ssh() {

--- a/vaibhavdesai137@gmail.com
+++ b/vaibhavdesai137@gmail.com
@@ -245,9 +245,6 @@ func main() {
 	flPasswordFile := pflag.String("password-file",
 		envString("", "GITSYNC_PASSWORD_FILE", "GIT_SYNC_PASSWORD_FILE"),
 		"the file from which the password or personal access token for git auth will be sourced")
-	flPasswordFileReload := pflag.Bool("password-file-reload",
-		envBool(false, "GITSYNC_PASSWORD_FILE_RELOAD"),
-		"reload the password from --password-file on each sync cycle, useful when password is rotated by an external system")
 	flCredentials := pflagCredentialSlice("credential", envString("", "GITSYNC_CREDENTIAL"), "one or more credentials (see --man for details) available for authentication")
 
 	flSSHKeyFiles := pflag.StringArray("ssh-key-file",
@@ -752,19 +749,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Finish populating credentials.
-	for i := range *flCredentials {
-		cred := &(*flCredentials)[i]
-		if cred.PasswordFile != "" {
-			passwordFileBytes, err := os.ReadFile(cred.PasswordFile)
-			if err != nil {
-				log.Error(err, "can't read password file", "file", cred.PasswordFile)
-				os.Exit(1)
-			}
-			cred.Password = string(passwordFileBytes)
-		}
-	}
-
 	// If the --repo or any submodule uses SSH, we need to know which keys.
 	if err := git.SetupGitSSH(*flSSHKnownHosts, *flSSHKeyFiles, *flSSHKnownHostsFile); err != nil {
 		log.Error(err, "can't set up git SSH", "keyFiles", *flSSHKeyFiles, "useKnownHosts", *flSSHKnownHosts, "knownHostsFile", *flSSHKnownHostsFile)
@@ -888,15 +872,15 @@ func main() {
 		for _, cred := range *flCredentials {
 			password := cred.Password
 
-			// If reload flag is set and this credential has a password file,
-			// re-read it from disk to pick up token rotation (e.g. from Vault)
-			if *flPasswordFileReload && cred.PasswordFile != "" {
+			// If this credential has a password file, re-read it from disk
+			// to pick up token rotation (e.g. from Vault)
+			if cred.PasswordFile != "" {
 				passwordFileBytes, err := os.ReadFile(cred.PasswordFile)
 				if err != nil {
-					return fmt.Errorf("can't reload password file %q: %w", cred.PasswordFile, err)
+					return fmt.Errorf("can't read password file %q: %w", cred.PasswordFile, err)
 				}
 				password = string(passwordFileBytes)
-				git.log.V(3).Info("reloaded password from file", "file", cred.PasswordFile)
+				git.log.V(3).Info("read password from file", "file", cred.PasswordFile)
 			}
 
 			if err := git.StoreCredentials(ctx, cred.URL, cred.Username, password); err != nil {
@@ -2600,16 +2584,10 @@ OPTIONS
     --password-file <string>, $GITSYNC_PASSWORD_FILE
             The file from which the password or personal access token (see
             github docs) to use for git authentication (see --username) will be
-            read.  See also $GITSYNC_PASSWORD.
-
-    --password-file-reload, $GITSYNC_PASSWORD_FILE_RELOAD
-            Reload the password from --password-file on each sync cycle.  This
-            is useful when using dynamic credentials that are rotated by an
-            external system (e.g. Vault's dynamic GitHub secrets engine).
-            Without this flag, the password file is read once at startup and
-            cached in memory.  With this flag enabled, the file will be re-read
-            before each sync attempt, allowing git-sync to pick up token
-            rotations.  If not specified, this defaults to false.
+            read.  The file is re-read before each sync attempt, allowing
+            git-sync to pick up token rotations automatically (e.g. when 
+						credentials are dynamically rotated by external systems).
+            See also $GITSYNC_PASSWORD.
 
     --period <duration>, $GITSYNC_PERIOD
             How long to wait between sync attempts.  This must be at least


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**
Adds flags for --hooks-async and --hooks-before-symlink

**Which issue(s) this PR fixes:**
Fixes https://github.com/kubernetes/git-sync/issues/975

Special notes for your reviewer:

Does this PR introduce a user-facing change?:
- No, the initial approach to create a new flag is gone based on review comments
- The PR now changes the default behavior of `--askpass-url` to read password from file on every sync

/kind feature