### PR TITLE
Extend lock file detection to include worktree locks

### DIFF
--- a/main.go
+++ b/main.go
@@ -1337,7 +1337,7 @@ func (git *repoSync) removeStaleWorktrees() (int, error) {
 }
 
 func hasGitLockFile(gitRoot absPath) (string, error) {
-	gitLockFiles := []string{"shallow.lock"}
+	gitLockFiles := []string{"shallow.lock", "index.lock", "HEAD.lock", "refs.lock"}
 	for _, lockFile := range gitLockFiles {
 		lockFilePath := gitRoot.Join(".git", lockFile).String()
 		_, err := os.Stat(lockFilePath)
@@ -1347,6 +1347,28 @@ func hasGitLockFile(gitRoot absPath) (string, error) {
 			return lockFilePath, err
 		}
 	}
+
+	// Check for lock files in worktrees
+	worktreeDir := gitRoot.Join(".git", "worktrees").String()
+	if _, err := os.Stat(worktreeDir); err == nil {
+		entries, err := os.ReadDir(worktreeDir)
+		if err != nil {
+			return "", err
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			indexLockPath := filepath.Join(worktreeDir, entry.Name(), "index.lock")
+			_, err := os.Stat(indexLockPath)
+			if err == nil {
+				return indexLockPath, nil
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return indexLockPath, err
+			}
+		}
+	}
+
 	return "", nil
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -441,6 +441,22 @@ func TestHasGitLockFile(t *testing.T) {
 			inputFilePath:  []string{".git", "shallow.lock"},
 			expectLockFile: true,
 		},
+		"index.lock file": {
+			inputFilePath:  []string{".git", "index.lock"},
+			expectLockFile: true,
+		},
+		"HEAD.lock file": {
+			inputFilePath:  []string{".git", "HEAD.lock"},
+			expectLockFile: true,
+		},
+		"refs.lock file": {
+			inputFilePath:  []string{".git", "refs.lock"},
+			expectLockFile: true,
+		},
+		"worktree index.lock file": {
+			inputFilePath:  []string{".git", "worktrees", "abcd1234", "index.lock"},
+			expectLockFile: true,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
Extend git-sync lock file recovery to handle worktree locks in addition to shallow.lock.

## Problem
git-sync v4.3.0 PR #914 detects and recovers from orphaned shallow.lock files, but fails to detect index.lock files in git worktrees. This causes CrashLoopBackOff when worktree index.lock persists from crashed git operations.

## Solution
Expanded lock file detection in hasGitLockFile() to include:
- index.lock (main repo)
- HEAD.lock (main repo)
- refs.lock (main repo)
- index.lock files in .git/worktrees/*/

## Implementation Details
- Modified hasGitLockFile() to check multiple lock file types in main .git directory
- Added worktree lock detection by scanning .git/worktrees/ directories
- Existing initRepo() recovery flow properly removes all detected locks via removeDirContents()
- Added comprehensive test cases for all lock file types including worktrees

## Testing
- All existing tests pass
- New test cases verify detection of index.lock, HEAD.lock, refs.lock in main repo
- New test case verifies detection of worktree index.lock files

Fixes the issue where worktree index.lock files cause CrashLoopBackOff on container restart.