### PR TITLE
feat: add `org.opencontainers.image.source` label to Dockerfile

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -162,4 +162,6 @@ WORKDIR /tmp
 # override this, and we assume they are handling permissions themselves.
 ENV GITSYNC_ROOT=/git
 
+LABEL org.opencontainers.image.source="https://github.com/kubernetes/git-sync"
+
 ENTRYPOINT ["/{ARG_BIN}"]


### PR DESCRIPTION
The `org.opencontainers.image.source` label can be used by tools or humans to find more information about this image.

[Renovatebot](https://docs.renovatebot.com) for examples uses it to retrieve [release notes](https://docs.renovatebot.com/modules/datasource/docker/#description). They will be displayed in the PRs created by renovate when it updates the container image.