### PR TITLE
[Feat] Pre exechook

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,21 +445,22 @@ OPTIONS
             will take precedence.  If not specified, this defaults to 10
             seconds ("10s").
 
-    --pre-exechook-backoff <duration>, $GITSYNC_PRE_EXECHOOK_BACKOFF
-        The time to wait before retrying a failed --pre-exechook-command.  If
-        not specified, this defaults to 3 seconds ("3s").
+    --pre-publish-exechook-backoff <duration>, $GITSYNC_PRE_PUBLISH_EXECHOOK_BACKOFF
+            The time to wait before retrying a failed
+            --pre-publish-exechook-command. If not specified, this defaults to 
+            3 seconds ("3s").
 
-    --pre-exechook-command <string>, $GITSYNC_PRE_EXECHOOK_COMMAND
-			An optional command to be executed after syncing a new hash of the 
-	        remote repository but before publishing the symlink (see --link).
-	        This command does not take any arguments and
-            executes with the synced repo as its working directory. The
-            $GITSYNC_HASH environment variable will be set to the previous git hash that
-            was synced. This hook will always be invoked as it runs before any sync attempt.
+    --pre-publish-exechook-command <string>, $GITSYNC_PRE_PUBLISH_EXECHOOK_COMMAND
+            An optional command to be executed after syncing a new hash of the
+            remote repository but before publishing the symlink (see --link).
+            This command does not take any arguments and executes with the
+            synced repo as its working directory. The $GITSYNC_HASH environment
+            variable will be set to the previous git hash that was synced. This
+            hook will always be invoked as it runs before any sync attempt.
 
-    --pre-exechook-timeout <duration>, $GITSYNC_PRE_EXECHOOK_TIMEOUT
-            The timeout for the --pre-exechook-command.  If not specifid, this
-            defaults to 30 seconds ("30s").
+    --pre-publish-exechook-timeout <duration>, $GITSYNC_PRE_PUBLISH_EXECHOOK_TIMEOUT
+            The timeout for the --pre-publish-exechook-command.  If not        
+            specified this defaults to 30 seconds ("30s").
 
     --ref <string>, $GITSYNC_REF
             The git revision (branch, tag, or hash) to check out.  If not

--- a/README.md
+++ b/README.md
@@ -297,22 +297,6 @@ OPTIONS
             The timeout for the --exechook-command.  If not specifid, this
             defaults to 30 seconds ("30s").
 
-    --pre-exechook-backoff <duration>, $GITSYNC_PRE_EXECHOOK_BACKOFF
-            The time to wait before retrying a failed --pre-exechook-command.  If
-            not specified, this defaults to 3 seconds ("3s").
-
-    --pre-exechook-command <string>, $GITSYNC_PRE_EXECHOOK_COMMAND
-            An optional command to be executed before syncing a new hash of the
-            remote repository.  This command does not take any arguments and
-            executes with the synced repo as its working directory. The
-            $GITSYNC_HASH environment variable will be set to the previous git hash that
-            was synced. This hook will always be invoked as it runs before any sync attempt.
-
-    --pre-exechook-timeout <duration>, $GITSYNC_PRE_EXECHOOK_TIMEOUT
-            The timeout for the --pre-exechook-command.  If not specifid, this
-            defaults to 30 seconds ("30s").
-
-
     --filter <string>, $GITSYNC_FILTER
             Use partial clone with the specified filter.  This can reduce
             the amount of data transferred when cloning large repositories.
@@ -460,6 +444,22 @@ OPTIONS
             10ms.  This flag obsoletes --wait, but if --wait is specified, it
             will take precedence.  If not specified, this defaults to 10
             seconds ("10s").
+
+    --pre-exechook-backoff <duration>, $GITSYNC_PRE_EXECHOOK_BACKOFF
+        The time to wait before retrying a failed --pre-exechook-command.  If
+        not specified, this defaults to 3 seconds ("3s").
+
+    --pre-exechook-command <string>, $GITSYNC_PRE_EXECHOOK_COMMAND
+			An optional command to be executed after syncing a new hash of the 
+	        remote repository but before publishing the symlink (see --link).
+	        This command does not take any arguments and
+            executes with the synced repo as its working directory. The
+            $GITSYNC_HASH environment variable will be set to the previous git hash that
+            was synced. This hook will always be invoked as it runs before any sync attempt.
+
+    --pre-exechook-timeout <duration>, $GITSYNC_PRE_EXECHOOK_TIMEOUT
+            The timeout for the --pre-exechook-command.  If not specifid, this
+            defaults to 30 seconds ("30s").
 
     --ref <string>, $GITSYNC_REF
             The git revision (branch, tag, or hash) to check out.  If not

--- a/README.md
+++ b/README.md
@@ -297,6 +297,22 @@ OPTIONS
             The timeout for the --exechook-command.  If not specifid, this
             defaults to 30 seconds ("30s").
 
+    --pre-exechook-backoff <duration>, $GITSYNC_PRE_EXECHOOK_BACKOFF
+            The time to wait before retrying a failed --pre-exechook-command.  If
+            not specified, this defaults to 3 seconds ("3s").
+
+    --pre-exechook-command <string>, $GITSYNC_PRE_EXECHOOK_COMMAND
+            An optional command to be executed before syncing a new hash of the
+            remote repository.  This command does not take any arguments and
+            executes with the synced repo as its working directory. The
+            $GITSYNC_HASH environment variable will be set to the previous git hash that
+            was synced. This hook will always be invoked as it runs before any sync attempt.
+
+    --pre-exechook-timeout <duration>, $GITSYNC_PRE_EXECHOOK_TIMEOUT
+            The timeout for the --pre-exechook-command.  If not specifid, this
+            defaults to 30 seconds ("30s").
+
+
     --filter <string>, $GITSYNC_FILTER
             Use partial clone with the specified filter.  This can reduce
             the amount of data transferred when cloning large repositories.

--- a/main.go
+++ b/main.go
@@ -237,15 +237,15 @@ func main() {
 		envDuration(3*time.Second, "GITSYNC_EXECHOOK_BACKOFF", "GIT_SYNC_EXECHOOK_BACKOFF"),
 		"the time to wait before retrying a failed exechook")
 
-	flPreExechookCommand := pflag.String("pre-exechook-command",
-		envString("", "GITSYNC_PRE_EXECHOOK_COMMAND", "GIT_SYNC_PRE_EXECHOOK_COMMAND"),
+	flPrePubExechookCommand := pflag.String("pre-publish-exechook-command",
+		envString("", "GITSYNC_PRE_PUBLISH_EXECHOOK_COMMAND"),
 		"an optional command to be run before syncs complete (must be idempotent)")
-	flPreExechookTimeout := pflag.Duration("pre-exechook-timeout",
-		envDuration(30*time.Second, "GITSYNC_PRE_EXECHOOK_TIMEOUT", "GIT_SYNC_PRE_EXECHOOK_TIMEOUT"),
-		"the timeout for the pre-exechook")
-	flPreExechookBackoff := pflag.Duration("pre-exechook-backoff",
-		envDuration(3*time.Second, "GITSYNC_PRE_EXECHOOK_BACKOFF", "GIT_SYNC_PRE_EXECHOOK_BACKOFF"),
-		"the time to wait before retrying a failed pre-exechook")
+	flPrePubExechookTimeout := pflag.Duration("pre-publish-exechook-timeout",
+		envDuration(30*time.Second, "GITSYNC_PRE_PUBLISH_EXECHOOK_TIMEOUT"),
+		"the timeout for the pre-publish-exechook")
+	flPrePubExechookBackoff := pflag.Duration("pre-publish-exechook-backoff",
+		envDuration(3*time.Second, "GITSYNC_PRE_PUBLISH_EXECHOOK_BACKOFF"),
+		"the time to wait before retrying a failed pre-publish-exechook")
 
 	flWebhookURL := pflag.String("webhook-url",
 		envString("", "GITSYNC_WEBHOOK_URL", "GIT_SYNC_WEBHOOK_URL"),
@@ -558,12 +558,12 @@ func main() {
 		}
 	}
 
-	if *flPreExechookCommand != "" {
-		if *flPreExechookTimeout < time.Second {
-			fatalConfigErrorf(log, true, "invalid flag: --pre-exechook-timeout must be at least 1s")
+	if *flPrePubExechookCommand != "" {
+		if *flPrePubExechookTimeout < time.Second {
+			fatalConfigErrorf(log, true, "invalid flag: --pre-publish-exechook-timeout must be at least 1s")
 		}
-		if *flPreExechookBackoff < time.Second {
-			fatalConfigErrorf(log, true, "invalid flag: --pre-exechook-backoff must be at least 1s")
+		if *flPrePubExechookBackoff < time.Second {
+			fatalConfigErrorf(log, true, "invalid flag: --pre-publish-exechook-backoff must be at least 1s")
 		}
 	}
 
@@ -908,30 +908,30 @@ func main() {
 		go exechookRunner.Run(context.Background())
 	}
 
-	// Startup pre-exechooks goroutine
-	var preExechookRunner *hook.HookRunner
-	if *flPreExechookCommand != "" {
-		logname := "pre-exechook"
+	// Startup pre-publish-exechooks goroutine
+	var prePubExechookRunner *hook.HookRunner
+	if *flPrePubExechookCommand != "" {
+		logname := "pre-publish-exechook"
 		log := log.WithName(logname)
 		exechook := hook.NewExechook(
 			logname,
 			cmd.NewRunner(log),
-			*flPreExechookCommand,
+			*flPrePubExechookCommand,
 			func(hash string) string {
 				return git.worktreeFor(hash).Path().String()
 			},
 			[]string{},
-			*flPreExechookTimeout,
+			*flPrePubExechookTimeout,
 			log,
 		)
-		preExechookRunner = hook.NewHookRunner(
+		prePubExechookRunner = hook.NewHookRunner(
 			exechook,
-			*flPreExechookBackoff,
+			*flPrePubExechookBackoff,
 			hook.NewHookData(),
 			log,
 			*flOneTime,
 		)
-		go preExechookRunner.Run(context.Background())
+		go prePubExechookRunner.Run(context.Background())
 	}
 
 	// Setup signal notify channel
@@ -988,8 +988,8 @@ func main() {
 	syncHooks := syncHooks{
 		refreshCreds: refreshCreds,
 		beforePublish: func(hash string) error {
-			if preExechookRunner != nil {
-				preExechookRunner.Send(hash)
+			if prePubExechookRunner != nil {
+				prePubExechookRunner.Send(hash)
 			}
 			return nil
 		},
@@ -1065,6 +1065,11 @@ func main() {
 				// Assumes that if hook channels are not nil, they will have at
 				// least one value before getting closed
 				exitCode := 0 // is 0 if all hooks succeed, else is 1
+				if prePubExechookRunner != nil && changed {
+					if err := prePubExechookRunner.WaitForCompletion(); err != nil {
+						exitCode = 1
+					}
+				}
 				if exechookRunner != nil {
 					if err := exechookRunner.WaitForCompletion(); err != nil {
 						exitCode = 1
@@ -1908,6 +1913,12 @@ func (git *repoSync) SyncRepo(ctx context.Context, syncHooks syncHooks) (bool, s
 
 		// If we have a new hash, update the symlink to point to the new worktree.
 		if changed {
+			// If the previous run crashed before publishing the link, then we
+			// must call the pre-publish hook, and since changed is true, we will.
+			// we will. If the previous run crashed after publishing the link,
+			// then we do not need to call the pre-publish hook, and since
+			// changed is false, we won't. The post-publish hooks are called in
+			// both cases.
 			err := syncHooks.beforePublish(newWorktree.Hash())
 			if err != nil {
 				return false, "", err
@@ -2591,15 +2602,15 @@ OPTIONS
 
     --exechook-command <string>, $GITSYNC_EXECHOOK_COMMAND
             An optional command to be executed after syncing a new hash of the
-            remote repository and publishing the symlink (see --link).
-            This command does not take any arguments and
-            executes with the synced repo as its working directory.  The
-            $GITSYNC_HASH environment variable will be set to the git hash that
-            was synced.  If, at startup, git-sync finds that the --root already
-            has the correct hash, this hook will still be invoked.  This means
-            that hooks can be invoked more than one time per hash, so they
-            must be idempotent.  This flag obsoletes --sync-hook-command, but
-            if sync-hook-command is specified, it will take precedence.
+            remote repository and publishing the symlink (see --link). This
+            command does not take any arguments and executes with the synced
+            repo as its working directory.  The $GITSYNC_HASH environment
+            variable will be set to the git hash that was synced.  If, at
+            startup, git-sync finds that the --root already has the correct
+            hash, this hook will still be invoked.  This means that hooks can
+            be invoked more than one time per hash, so they must be idempotent.
+            This flag obsoletes --sync-hook-command, but if sync-hook-command
+            is specified, it will take precedence.
 
     --exechook-timeout <duration>, $GITSYNC_EXECHOOK_TIMEOUT
             The timeout for the --exechook-command.  If not specifid, this
@@ -2753,21 +2764,22 @@ OPTIONS
             will take precedence.  If not specified, this defaults to 10
             seconds ("10s").
 
-    --pre-exechook-backoff <duration>, $GITSYNC_PRE_EXECHOOK_BACKOFF
-            The time to wait before retrying a failed --pre-exechook-command.  If
-            not specified, this defaults to 3 seconds ("3s").
+    --pre-publish-exechook-backoff <duration>, $GITSYNC_PRE_PUBLISH_EXECHOOK_BACKOFF
+            The time to wait before retrying a failed
+            --pre-publish-exechook-command. If not specified, this defaults to 
+            3 seconds ("3s").
 
-    --pre-exechook-command <string>, $GITSYNC_PRE_EXECHOOK_COMMAND
-            An optional command to be executed after syncing a new hash of the 
+    --pre-publish-exechook-command <string>, $GITSYNC_PRE_PUBLISH_EXECHOOK_COMMAND
+            An optional command to be executed after syncing a new hash of the
             remote repository but before publishing the symlink (see --link).
-            This command does not take any arguments and
-            executes with the synced repo as its working directory. The
-            $GITSYNC_HASH environment variable will be set to the previous git hash that
-            was synced. This hook will always be invoked as it runs before any sync attempt.
+            This command does not take any arguments and executes with the
+            synced repo as its working directory. The $GITSYNC_HASH environment
+            variable will be set to the previous git hash that was synced. This
+            hook will always be invoked as it runs before any sync attempt.
 
-    --pre-exechook-timeout <duration>, $GITSYNC_PRE_EXECHOOK_TIMEOUT
-            The timeout for the --pre-exechook-command.  If not specifid, this
-            defaults to 30 seconds ("30s").
+    --pre-publish-exechook-timeout <duration>, $GITSYNC_PRE_PUBLISH_EXECHOOK_TIMEOUT
+            The timeout for the --pre-publish-exechook-command.  If not        
+            specified this defaults to 30 seconds ("30s").
 
     --ref <string>, $GITSYNC_REF
             The git revision (branch, tag, or hash) to check out.  If not

--- a/main.go
+++ b/main.go
@@ -982,6 +982,7 @@ func main() {
 	syncCount := uint64(0)
 	initialSyncDone := false
 	waitTime := *flInitPeriod
+	prevHash := ""
 	// getMaxFailures returns the effective max-failure limit for the current
 	// phase.  During the initial sync phase, --init-max-failures (if set)
 	// overrides --max-failures; otherwise --max-failures applies.
@@ -994,7 +995,6 @@ func main() {
 	for {
 		start := time.Now()
 		ctx, cancel := context.WithTimeout(context.Background(), *flSyncTimeout)
-		prevHash := ""
 
 		if preExechookRunner != nil {
 			preExechookRunner.Send(prevHash)

--- a/main.go
+++ b/main.go
@@ -230,6 +230,16 @@ func main() {
 		envDuration(3*time.Second, "GITSYNC_EXECHOOK_BACKOFF", "GIT_SYNC_EXECHOOK_BACKOFF"),
 		"the time to wait before retrying a failed exechook")
 
+	flPreExechookCommand := pflag.String("pre-exechook-command",
+		envString("", "GITSYNC_PRE_EXECHOOK_COMMAND", "GIT_SYNC_PRE_EXECHOOK_COMMAND"),
+		"an optional command to be run before syncs complete (must be idempotent)")
+	flPreExechookTimeout := pflag.Duration("pre-exechook-timeout",
+		envDuration(30*time.Second, "GITSYNC_PRE_EXECHOOK_TIMEOUT", "GIT_SYNC_PRE_EXECHOOK_TIMEOUT"),
+		"the timeout for the pre-exechook")
+	flPreExechookBackoff := pflag.Duration("pre-exechook-backoff",
+		envDuration(3*time.Second, "GITSYNC_PRE_EXECHOOK_BACKOFF", "GIT_SYNC_PRE_EXECHOOK_BACKOFF"),
+		"the time to wait before retrying a failed pre-exechook")
+
 	flWebhookURL := pflag.String("webhook-url",
 		envString("", "GITSYNC_WEBHOOK_URL", "GIT_SYNC_WEBHOOK_URL"),
 		"a URL for optional webhook notifications when syncs complete (must be idempotent)")
@@ -538,6 +548,15 @@ func main() {
 		}
 		if *flExechookBackoff < time.Second {
 			fatalConfigErrorf(log, true, "invalid flag: --exechook-backoff must be at least 1s")
+		}
+	}
+
+	if *flPreExechookCommand != "" {
+		if *flPreExechookTimeout < time.Second {
+			fatalConfigErrorf(log, true, "invalid flag: --pre-exechook-timeout must be at least 1s")
+		}
+		if *flPreExechookBackoff < time.Second {
+			fatalConfigErrorf(log, true, "invalid flag: --pre-exechook-backoff must be at least 1s")
 		}
 	}
 
@@ -859,8 +878,10 @@ func main() {
 	// Startup exechooks goroutine
 	var exechookRunner *hook.HookRunner
 	if *flExechookCommand != "" {
-		log := log.WithName("exechook")
+		logname := "exechook"
+		log := log.WithName(logname)
 		exechook := hook.NewExechook(
+			logname,
 			cmd.NewRunner(log),
 			*flExechookCommand,
 			func(hash string) string {
@@ -878,6 +899,32 @@ func main() {
 			*flOneTime,
 		)
 		go exechookRunner.Run(context.Background())
+	}
+
+	// Startup pre-exechooks goroutine
+	var preExechookRunner *hook.HookRunner
+	if *flPreExechookCommand != "" {
+		logname := "pre-exechook"
+		log := log.WithName(logname)
+		exechook := hook.NewExechook(
+			logname,
+			cmd.NewRunner(log),
+			*flPreExechookCommand,
+			func(hash string) string {
+				return git.worktreeFor(hash).Path().String()
+			},
+			[]string{},
+			*flPreExechookTimeout,
+			log,
+		)
+		preExechookRunner = hook.NewHookRunner(
+			exechook,
+			*flPreExechookBackoff,
+			hook.NewHookData(),
+			log,
+			*flOneTime,
+		)
+		go preExechookRunner.Run(context.Background())
 	}
 
 	// Setup signal notify channel
@@ -947,6 +994,11 @@ func main() {
 	for {
 		start := time.Now()
 		ctx, cancel := context.WithTimeout(context.Background(), *flSyncTimeout)
+		prevHash := ""
+
+		if preExechookRunner != nil {
+			preExechookRunner.Send(prevHash)
+		}
 
 		if changed, hash, err := git.SyncRepo(ctx, refreshCreds); err != nil {
 			failCount++
@@ -980,6 +1032,9 @@ func main() {
 				}
 				if exechookRunner != nil {
 					exechookRunner.Send(hash)
+				}
+				if preExechookRunner != nil {
+					prevHash = hash
 				}
 				updateSyncMetrics(metricKeySuccess, start)
 			} else {
@@ -2527,6 +2582,22 @@ OPTIONS
     --exechook-timeout <duration>, $GITSYNC_EXECHOOK_TIMEOUT
             The timeout for the --exechook-command.  If not specifid, this
             defaults to 30 seconds ("30s").
+
+	--pre-exechook-backoff <duration>, $GITSYNC_PRE_EXECHOOK_BACKOFF
+            The time to wait before retrying a failed --pre-exechook-command.  If
+            not specified, this defaults to 3 seconds ("3s").
+
+    --pre-exechook-command <string>, $GITSYNC_PRE_EXECHOOK_COMMAND
+            An optional command to be executed before syncing a new hash of the
+            remote repository.  This command does not take any arguments and
+            executes with the synced repo as its working directory. The
+            $GITSYNC_HASH environment variable will be set to the previous git hash that
+            was synced. This hook will always be invoked as it runs before any sync attempt.
+
+    --pre-exechook-timeout <duration>, $GITSYNC_PRE_EXECHOOK_TIMEOUT
+            The timeout for the --pre-exechook-command.  If not specifid, this
+            defaults to 30 seconds ("30s").
+
 
     --filter <string>, $GITSYNC_FILTER
             Use partial clone with the specified filter.  This can reduce

--- a/main.go
+++ b/main.go
@@ -2583,7 +2583,7 @@ OPTIONS
             The timeout for the --exechook-command.  If not specifid, this
             defaults to 30 seconds ("30s").
 
-	--pre-exechook-backoff <duration>, $GITSYNC_PRE_EXECHOOK_BACKOFF
+    --pre-exechook-backoff <duration>, $GITSYNC_PRE_EXECHOOK_BACKOFF
             The time to wait before retrying a failed --pre-exechook-command.  If
             not specified, this defaults to 3 seconds ("3s").
 
@@ -2597,7 +2597,6 @@ OPTIONS
     --pre-exechook-timeout <duration>, $GITSYNC_PRE_EXECHOOK_TIMEOUT
             The timeout for the --pre-exechook-command.  If not specifid, this
             defaults to 30 seconds ("30s").
-
 
     --filter <string>, $GITSYNC_FILTER
             Use partial clone with the specified filter.  This can reduce

--- a/main.go
+++ b/main.go
@@ -133,6 +133,13 @@ type repoSync struct {
 	appTokenExpiry time.Time     // time when github app auth token expires
 }
 
+// syncHooks manages the refresh of credentials and hooks.
+type syncHooks struct {
+	refreshCreds  func(ctx context.Context) error
+	beforePublish func(hash string) error
+	afterPublish  func(hash string) error
+}
+
 func main() {
 	// In case we come up as pid 1, act as init.
 	if os.Getpid() == 1 {
@@ -978,11 +985,28 @@ func main() {
 		return nil
 	}
 
+	syncHooks := syncHooks{
+		refreshCreds: refreshCreds,
+		beforePublish: func(hash string) error {
+			if preExechookRunner != nil {
+				preExechookRunner.Send(hash)
+			}
+			return nil
+		},
+		afterPublish: func(hash string) error {
+			if exechookRunner != nil {
+				exechookRunner.Send(hash)
+			}
+			if webhookRunner != nil {
+				webhookRunner.Send(hash)
+			}
+			return nil
+		},
+	}
 	failCount := 0
 	syncCount := uint64(0)
 	initialSyncDone := false
 	waitTime := *flInitPeriod
-	prevHash := ""
 	// getMaxFailures returns the effective max-failure limit for the current
 	// phase.  During the initial sync phase, --init-max-failures (if set)
 	// overrides --max-failures; otherwise --max-failures applies.
@@ -996,11 +1020,7 @@ func main() {
 		start := time.Now()
 		ctx, cancel := context.WithTimeout(context.Background(), *flSyncTimeout)
 
-		if preExechookRunner != nil {
-			preExechookRunner.Send(prevHash)
-		}
-
-		if changed, hash, err := git.SyncRepo(ctx, refreshCreds); err != nil {
+		if changed, hash, err := git.SyncRepo(ctx, syncHooks); err != nil {
 			failCount++
 			updateSyncMetrics(metricKeyError, start)
 			if maxFails := getMaxFailures(); maxFails >= 0 && failCount >= maxFails {
@@ -1026,15 +1046,6 @@ func main() {
 					} else {
 						log.V(3).Info("touched touch-file", "path", absTouchFile)
 					}
-				}
-				if webhookRunner != nil {
-					webhookRunner.Send(hash)
-				}
-				if exechookRunner != nil {
-					exechookRunner.Send(hash)
-				}
-				if preExechookRunner != nil {
-					prevHash = hash
 				}
 				updateSyncMetrics(metricKeySuccess, start)
 			} else {
@@ -1809,10 +1820,10 @@ func (git *repoSync) currentWorktree() (worktree, error) {
 // SyncRepo syncs the repository to the desired ref, publishes it via the link,
 // and tries to clean up any detritus.  This function returns whether the
 // current hash has changed and what the new hash is.
-func (git *repoSync) SyncRepo(ctx context.Context, refreshCreds func(context.Context) error) (bool, string, error) {
+func (git *repoSync) SyncRepo(ctx context.Context, syncHooks syncHooks) (bool, string, error) {
 	git.log.V(3).Info("syncing", "repo", redactURL(git.repo))
 
-	if err := refreshCreds(ctx); err != nil {
+	if err := syncHooks.refreshCreds(ctx); err != nil {
 		return false, "", fmt.Errorf("credential refresh failed: %w", err)
 	}
 
@@ -1897,7 +1908,12 @@ func (git *repoSync) SyncRepo(ctx context.Context, refreshCreds func(context.Con
 
 		// If we have a new hash, update the symlink to point to the new worktree.
 		if changed {
-			err := git.publishSymlink(newWorktree)
+			err := syncHooks.beforePublish(newWorktree.Hash())
+			if err != nil {
+				return false, "", err
+			}
+
+			err = git.publishSymlink(newWorktree)
 			if err != nil {
 				return false, "", err
 			}
@@ -1908,6 +1924,11 @@ func (git *repoSync) SyncRepo(ctx context.Context, refreshCreds func(context.Con
 					git.log.Error(err, "can't change stale worktree mtime", "path", currentWorktree.Path())
 				}
 			}
+		}
+
+		err := syncHooks.afterPublish(newWorktree.Hash())
+		if err != nil {
+			return false, "", err
 		}
 
 		// Mark ourselves as "ready".
@@ -2570,7 +2591,8 @@ OPTIONS
 
     --exechook-command <string>, $GITSYNC_EXECHOOK_COMMAND
             An optional command to be executed after syncing a new hash of the
-            remote repository.  This command does not take any arguments and
+            remote repository and publishing the symlink (see --link).
+            This command does not take any arguments and
             executes with the synced repo as its working directory.  The
             $GITSYNC_HASH environment variable will be set to the git hash that
             was synced.  If, at startup, git-sync finds that the --root already
@@ -2581,21 +2603,6 @@ OPTIONS
 
     --exechook-timeout <duration>, $GITSYNC_EXECHOOK_TIMEOUT
             The timeout for the --exechook-command.  If not specifid, this
-            defaults to 30 seconds ("30s").
-
-    --pre-exechook-backoff <duration>, $GITSYNC_PRE_EXECHOOK_BACKOFF
-            The time to wait before retrying a failed --pre-exechook-command.  If
-            not specified, this defaults to 3 seconds ("3s").
-
-    --pre-exechook-command <string>, $GITSYNC_PRE_EXECHOOK_COMMAND
-            An optional command to be executed before syncing a new hash of the
-            remote repository.  This command does not take any arguments and
-            executes with the synced repo as its working directory. The
-            $GITSYNC_HASH environment variable will be set to the previous git hash that
-            was synced. This hook will always be invoked as it runs before any sync attempt.
-
-    --pre-exechook-timeout <duration>, $GITSYNC_PRE_EXECHOOK_TIMEOUT
-            The timeout for the --pre-exechook-command.  If not specifid, this
             defaults to 30 seconds ("30s").
 
     --filter <string>, $GITSYNC_FILTER
@@ -2745,6 +2752,22 @@ OPTIONS
             10ms.  This flag obsoletes --wait, but if --wait is specified, it
             will take precedence.  If not specified, this defaults to 10
             seconds ("10s").
+
+    --pre-exechook-backoff <duration>, $GITSYNC_PRE_EXECHOOK_BACKOFF
+            The time to wait before retrying a failed --pre-exechook-command.  If
+            not specified, this defaults to 3 seconds ("3s").
+
+    --pre-exechook-command <string>, $GITSYNC_PRE_EXECHOOK_COMMAND
+            An optional command to be executed after syncing a new hash of the 
+            remote repository but before publishing the symlink (see --link).
+            This command does not take any arguments and
+            executes with the synced repo as its working directory. The
+            $GITSYNC_HASH environment variable will be set to the previous git hash that
+            was synced. This hook will always be invoked as it runs before any sync attempt.
+
+    --pre-exechook-timeout <duration>, $GITSYNC_PRE_EXECHOOK_TIMEOUT
+            The timeout for the --pre-exechook-command.  If not specifid, this
+            defaults to 30 seconds ("30s").
 
     --ref <string>, $GITSYNC_REF
             The git revision (branch, tag, or hash) to check out.  If not

--- a/pkg/hook/exechook.go
+++ b/pkg/hook/exechook.go
@@ -27,6 +27,8 @@ import (
 
 // Exechook implements Hook in terms of executing a command.
 type Exechook struct {
+	// Name
+	name string
 	// Runner
 	cmdrunner cmd.Runner
 	// Command to run
@@ -42,8 +44,9 @@ type Exechook struct {
 }
 
 // NewExechook returns a new Exechook.
-func NewExechook(cmdrunner cmd.Runner, command string, getWorktree func(string) string, args []string, timeout time.Duration, log logintf) *Exechook {
+func NewExechook(name string, cmdrunner cmd.Runner, command string, getWorktree func(string) string, args []string, timeout time.Duration, log logintf) *Exechook {
 	return &Exechook{
+		name:        name,
 		cmdrunner:   cmdrunner,
 		command:     command,
 		getWorktree: getWorktree,
@@ -55,7 +58,7 @@ func NewExechook(cmdrunner cmd.Runner, command string, getWorktree func(string) 
 
 // Name describes hook, implements Hook.Name.
 func (h *Exechook) Name() string {
-	return "exechook"
+	return h.name
 }
 
 // Do runs exechook.command, implements Hook.Do.

--- a/pkg/hook/exechook.go
+++ b/pkg/hook/exechook.go
@@ -71,10 +71,10 @@ func (h *Exechook) Do(ctx context.Context, hash string) error {
 	env := os.Environ()
 	env = append(env, envKV("GITSYNC_HASH", hash))
 
-	h.log.V(0).Info("running exechook", "hash", hash, "command", h.command, "timeout", h.timeout)
+	h.log.V(0).Info("running hook", "name", h.name, "hash", hash, "command", h.command, "timeout", h.timeout)
 	stdout, stderr, err := h.cmdrunner.Run(ctx, worktreePath, env, h.command, h.args...)
 	if err == nil {
-		h.log.V(1).Info("exechook succeeded", "hash", hash, "stdout", stdout, "stderr", stderr)
+		h.log.V(1).Info("hook succeeded", "name", h.name, "hash", hash, "stdout", stdout, "stderr", stderr)
 	}
 	return err
 }

--- a/pkg/hook/exechook.go
+++ b/pkg/hook/exechook.go
@@ -71,10 +71,10 @@ func (h *Exechook) Do(ctx context.Context, hash string) error {
 	env := os.Environ()
 	env = append(env, envKV("GITSYNC_HASH", hash))
 
-	h.log.V(0).Info("running hook", "name", h.name, "hash", hash, "command", h.command, "timeout", h.timeout)
+	h.log.V(0).Info("running exechook", "hash", hash, "command", h.command, "timeout", h.timeout)
 	stdout, stderr, err := h.cmdrunner.Run(ctx, worktreePath, env, h.command, h.args...)
 	if err == nil {
-		h.log.V(1).Info("hook succeeded", "name", h.name, "hash", hash, "stdout", stdout, "stderr", stderr)
+		h.log.V(1).Info("exechook succeeded", "hash", hash, "stdout", stdout, "stderr", stderr)
 	}
 	return err
 }

--- a/pkg/hook/exechook_test.go
+++ b/pkg/hook/exechook_test.go
@@ -29,6 +29,7 @@ func TestNotZeroReturnExechookDo(t *testing.T) {
 	t.Run("test not zero return code", func(t *testing.T) {
 		l := logging.New("", "", 0)
 		ch := NewExechook(
+			"exechook",
 			cmd.NewRunner(l),
 			"false",
 			func(string) string { return "/tmp" },
@@ -47,6 +48,7 @@ func TestZeroReturnExechookDo(t *testing.T) {
 	t.Run("test zero return code", func(t *testing.T) {
 		l := logging.New("", "", 0)
 		ch := NewExechook(
+			"exechook",
 			cmd.NewRunner(l),
 			"true",
 			func(string) string { return "/tmp" },
@@ -65,6 +67,7 @@ func TestTimeoutExechookDo(t *testing.T) {
 	t.Run("test timeout", func(t *testing.T) {
 		l := logging.New("", "", 0)
 		ch := NewExechook(
+			"exechook",
 			cmd.NewRunner(l),
 			"/bin/sh",
 			func(string) string { return "/tmp" },

--- a/test_e2e.sh
+++ b/test_e2e.sh
@@ -2560,6 +2560,138 @@ function e2e::exechook_startup_after_crash() {
 }
 
 ##############################################
+# Test pre-publish-exechook-success
+##############################################
+function e2e::pre_publish_exechook_success() {
+    cat /dev/null > "$RUNLOG"
+
+    # First sync
+    echo "${FUNCNAME[0]} 1" > "$REPO/file"
+    git -C "$REPO" commit -qam "${FUNCNAME[0]} 1"
+
+    GIT_SYNC \
+        --period=100ms \
+        --repo="file://$REPO" \
+        --root="$ROOT" \
+        --link="link" \
+        --pre-publish-exechook-command="/$EXECHOOK_COMMAND" \
+        &
+    wait_for_sync "${MAXWAIT}"
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/exechook"
+    assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]} 1"
+    assert_file_eq "$ROOT/link/exechook" "${FUNCNAME[0]} 1"
+    assert_file_eq "$ROOT/link/exechook-env" "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
+    assert_file_lines_eq "$RUNLOG" 1
+
+    # Move forward
+    echo "${FUNCNAME[0]} 2" > "$REPO/file"
+    git -C "$REPO" commit -qam "${FUNCNAME[0]} 2"
+    wait_for_sync "${MAXWAIT}"
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/exechook"
+    assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]} 2"
+    assert_file_eq "$ROOT/link/exechook" "${FUNCNAME[0]} 2"
+    assert_file_eq "$ROOT/link/exechook-env" "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
+    assert_file_lines_eq "$RUNLOG" 2
+}
+
+##############################################
+# Test pre-publish-exechook-fail-retry
+##############################################
+function e2e::pre_publish_exechook_fail_retry() {
+    cat /dev/null > "$RUNLOG"
+
+    # First sync - return a failure to ensure that we try again
+    GIT_SYNC \
+        --period=100ms \
+        --repo="file://$REPO" \
+        --root="$ROOT" \
+        --link="link" \
+        --pre-publish-exechook-command="/$EXECHOOK_COMMAND_FAIL" \
+        --pre-publish-exechook-backoff=1s \
+        &
+    sleep 3 # give it time to retry
+
+    # Check that exechook was called
+    assert_file_lines_ge "$RUNLOG" 2
+}
+
+######################################################
+# Test pre-publish-exechook-success with --one-time
+######################################################
+function e2e::pre_publish_exechook_success_once() {
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --root="$ROOT" \
+        --link="link" \
+        --pre-publish-exechook-command="/$EXECHOOK_COMMAND_SLEEPY"
+
+    wait_for_sync "${MAXWAIT}"
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_exists "$ROOT/link/exechook"
+    assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]}"
+    assert_file_eq "$ROOT/link/exechook" "${FUNCNAME[0]}"
+    assert_file_eq "$ROOT/link/exechook-env" "$EXECHOOK_ENVKEY=$EXECHOOK_ENVVAL"
+}
+
+###################################################
+# Test pre-publish-exechook-fail with --one-time
+###################################################
+function e2e::pre_publish_exechook_fail_once() {
+    cat /dev/null > "$RUNLOG"
+
+	assert_fail \
+        GIT_SYNC \
+            --one-time \
+            --repo="file://$REPO" \
+            --root="$ROOT" \
+            --link="link" \
+            --pre-publish-exechook-command="/$EXECHOOK_COMMAND_FAIL_SLEEPY" \
+            --pre-publish-exechook-backoff=1s
+
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]}"
+    assert_file_lines_eq "$RUNLOG" 1
+}
+
+##########################################################
+# Test pre-publish-exechook at startup with correct SHA
+##########################################################
+function e2e::pre_publish_exechook_startup_after_crash() {
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --ref="$MAIN_BRANCH" \
+        --root="$ROOT" \
+        --link="link"
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]}"
+
+    # No changes to repo, pre-publish-exechook-command is not called
+
+    cat /dev/null > "$RUNLOG"
+    GIT_SYNC \
+        --one-time \
+        --repo="file://$REPO" \
+        --ref="$MAIN_BRANCH" \
+        --root="$ROOT" \
+        --link="link" \
+        --pre-publish-exechook-command="/$EXECHOOK_COMMAND"
+    assert_link_exists "$ROOT/link"
+    assert_file_exists "$ROOT/link/file"
+    assert_file_absent "$ROOT/link/exechook"
+    assert_file_eq "$ROOT/link/file" "${FUNCNAME[0]}"
+    assert_file_lines_eq "$RUNLOG" 0
+}
+
+##############################################
 # Test webhook success
 ##############################################
 function e2e::webhook_success() {


### PR DESCRIPTION
/kind feature

What this PR does:
Fixes https://github.com/kubernetes/git-sync/issues/937

adds flags for `--pre-publish-exechook-command`, `--pre-publish-exechook-timeout` and `--pre-publish-exechook-backoff` to run a command similarly to the exechook but before publishing the new symlink

Follows https://github.com/kubernetes/git-sync/issues/937#issuecomment-2845597988 